### PR TITLE
Fix Unknown category list item

### DIFF
--- a/src/CategoriesList.tsx
+++ b/src/CategoriesList.tsx
@@ -7,17 +7,14 @@ import React from "react";
 import { CreateCategoryDialog } from "./CreateCategoryDialog";
 import { useSelector } from "react-redux";
 import { CategoryListItem } from "./CategoryListItem";
-import Checkbox from "@material-ui/core/Checkbox";
-import LabelIcon from "@material-ui/icons/Label";
-import LabelOutlinedIcon from "@material-ui/icons/LabelOutlined";
-import ListItemSecondaryAction from "@material-ui/core/ListItemSecondaryAction";
-import IconButton from "@material-ui/core/IconButton";
-import MoreHorizIcon from "@material-ui/icons/MoreHoriz";
 import { Category } from "./types/Category";
 import { createdCategoriesSelector } from "./store/selectors/createdCategoriesSelector";
+import { unknownCategorySelector } from "./store/selectors/unknownCategorySelector";
 
 export const CategoriesList = () => {
   const categories = useSelector(createdCategoriesSelector);
+
+  const unknownCategory = useSelector(unknownCategorySelector);
 
   const [
     openCreateCategoryDialog,
@@ -39,34 +36,10 @@ export const CategoriesList = () => {
           {categories.map((category: Category) => {
             return <CategoryListItem category={category} key={category.id} />;
           })}
-
-          <ListItem
-            dense
-            key="00000000-0000-0000-0000-000000000000"
-            id="00000000-0000-0000-0000-000000000000"
-          >
-            <ListItemIcon>
-              <Checkbox
-                checked
-                checkedIcon={<LabelIcon style={{ color: "#AAAAAA" }} />}
-                disableRipple
-                edge="start"
-                icon={<LabelOutlinedIcon style={{ color: "#AAAAAA" }} />}
-                tabIndex={-1}
-              />
-            </ListItemIcon>
-
-            <ListItemText
-              id="00000000-0000-0000-0000-000000000000"
-              primary="Unknown"
-            />
-
-            <ListItemSecondaryAction>
-              <IconButton edge="end">
-                <MoreHorizIcon />
-              </IconButton>
-            </ListItemSecondaryAction>
-          </ListItem>
+          <CategoryListItem
+            category={unknownCategory}
+            key={unknownCategory.id}
+          />
         </React.Fragment>
         <ListItem button onClick={onOpenCreateCategoryDialog}>
           <ListItemIcon>

--- a/src/CategoryListItem.tsx
+++ b/src/CategoryListItem.tsx
@@ -123,15 +123,17 @@ export const CategoryListItem = ({ category }: CategoryListItemProps) => {
             </Typography>
           </MenuItem>
 
-          <Divider />
-
-          <MenuItem onClick={onOpenEditCategoryDialog}>
-            <Typography variant="inherit">Edit category</Typography>
-          </MenuItem>
-
-          <MenuItem onClick={onCloseCategoryMenu}>
-            <Typography variant="inherit">Delete category</Typography>
-          </MenuItem>
+          {category.id !== "00000000-0000-0000-0000-000000000000" && (
+            <div>
+              <Divider />
+              <MenuItem onClick={onOpenEditCategoryDialog}>
+                <Typography variant="inherit">Edit category</Typography>
+              </MenuItem>
+              <MenuItem onClick={onCloseCategoryMenu}>
+                <Typography variant="inherit">Delete category</Typography>
+              </MenuItem>
+            </div>
+          )}
         </MenuList>
       </Menu>
 

--- a/src/store/selectors/unknownCategorySelector.ts
+++ b/src/store/selectors/unknownCategorySelector.ts
@@ -1,0 +1,12 @@
+import { Project } from "../../types/Project";
+import { Category } from "../../types/Category";
+
+export const unknownCategorySelector = ({
+  project,
+}: {
+  project: Project;
+}): Category => {
+  return project.categories.find((category: Category) => {
+    return category.id === "00000000-0000-0000-0000-000000000000";
+  })!;
+};


### PR DESCRIPTION
This PR replaces the 'Unknown' category list item which we'd manually duplicated with a normal CategoryListItem, added individually so as to avoid sorting problems.

To do this I've made a selector for finding the 'Unknown' category, and made the Edit/Delete category menu options conditional on the category in question not being the 'Unknown' category.

Not sure if this is the ideal way to solve this, but it makes 'Unknown' play nicely with the show/hide category functionality.