### PR TITLE
Fix conditional rendering

### DIFF
--- a/src/components/ImageGridAppBar/ImageGridAppBar.tsx
+++ b/src/components/ImageGridAppBar/ImageGridAppBar.tsx
@@ -111,13 +111,13 @@ export const ImageGridAppBar = () => {
         </AppBar>
       </Slide>
 
-      {Array.isArray(selectedImages) && selectedImages.length && (
+      {Array.isArray(selectedImages) && selectedImages.length ? (
         <ImageDialog
           image={_.find(images, (image) => image.id === selectedImages[0])!}
           onClose={onCloseImageDialog}
           open={openImageDialog}
         />
-      )}
+      ) : null}
 
       <ImageCategoryMenu
         anchorEl={categoryMenuAnchorEl as HTMLElement}


### PR DESCRIPTION
The code here was rendering '0' in the ImageGrid (`selectedImages.length`). I believe this may be because you can't mix and match the typescript `&&` and React `&&` conditional rendering operators in the same statement. Using the other conditional operator with a `null` 'else' result seems to fix this, though this could do with more testing once the image importer is fixed.