### PR TITLE
Assign train, val and test partitions to the images

### DIFF
--- a/src/components/FitClassifierDialog/DatasetSettingsListItem/DatasetSettingsListItem.tsx
+++ b/src/components/FitClassifierDialog/DatasetSettingsListItem/DatasetSettingsListItem.tsx
@@ -141,7 +141,7 @@ export const DatasetSettingsListItem = () => {
           <Button
             variant="contained"
             color="primary"
-            onClick={() => {}} //TODO implement this (see initalizeDataset function) (this should populate the data field and validation data field of your classifier)
+            onClick={() => {}} //TODO implement this (see initalizeDataset function) (this should separate new train and val dataset)
           >
             Initialize Dataset
           </Button>

--- a/src/components/FitClassifierDialog/FitClassifierDialog/FitClassifierDialog.tsx
+++ b/src/components/FitClassifierDialog/FitClassifierDialog/FitClassifierDialog.tsx
@@ -1,14 +1,19 @@
 import * as React from "react";
 import { FitClassifierDialogAppBar } from "../FitClassifierDialogAppBar";
 import { OptimizerSettingsListItem } from "../OptimizerSettingsListItem/OptimizerSettingsListItem";
-// additional stuff to test
 import { DatasetSettingsListItem } from "../DatasetSettingsListItem/DatasetSettingsListItem";
-import { useDispatch } from "react-redux";
-import { classifierSlice } from "../../../store/slices";
+import { useDispatch, useSelector } from "react-redux";
+import { classifierSlice, projectSlice } from "../../../store/slices";
 import { Dialog, DialogContent, List } from "@mui/material";
 import { ArchitectureSettingsListItem } from "../ArchitectureSettingsListItem";
 import { PreprocessingSettingsListItem } from "../../PreprocessingSettingsListItem/PreprocessingSettingsListItem";
 import { DialogTransition } from "../../DialogTransition";
+import {
+  categorizedImagesSelector,
+  trainingPercentageSelector,
+} from "../../../store/selectors";
+import { Image } from "../../../types/Image";
+import * as _ from "lodash";
 
 type FitClassifierDialogProps = {
   closeDialog: () => void;
@@ -19,9 +24,41 @@ type FitClassifierDialogProps = {
 export const FitClassifierDialog = (props: FitClassifierDialogProps) => {
   const { closeDialog, openedDialog, openedDrawer } = props;
 
+  const trainingPercentage = useSelector(trainingPercentageSelector);
+  const categorizedImages = useSelector(categorizedImagesSelector);
+
   const dispatch = useDispatch();
 
   const onFit = async () => {
+    //first assign train and val partition to all categorized images
+    const categorizedImagesIds = _.shuffle(categorizedImages).map(
+      (image: Image) => {
+        return image.id;
+      }
+    );
+
+    //separate ids into train and val datasets
+    const trainDataLength = Math.round(
+      trainingPercentage * categorizedImagesIds.length
+    );
+    const valDataLength = categorizedImagesIds.length - trainDataLength;
+
+    const trainDataIds = _.take(categorizedImagesIds, trainDataLength);
+    const valDataIds = _.takeRight(categorizedImagesIds, valDataLength);
+
+    dispatch(
+      projectSlice.actions.updateImagesPartition({
+        ids: trainDataIds,
+        partition: 0,
+      })
+    );
+    dispatch(
+      projectSlice.actions.updateImagesPartition({
+        ids: valDataIds,
+        partition: 1,
+      })
+    );
+
     dispatch(
       classifierSlice.actions.fit({
         onEpochEnd: (epoch: number, logs: any) => {

--- a/src/components/OpenMenu/OpenMenu.tsx
+++ b/src/components/OpenMenu/OpenMenu.tsx
@@ -39,7 +39,7 @@ export const OpenMenu = ({ popupState }: OpenMenuProps) => {
       tf.io.browserFiles([jsonFile, weightsFile])
     );
 
-    dispatch(classifierSlice.actions.updateOpened({ opened: model })); //TODO this should also update fitted (.predict() expects a fitted model.)
+    dispatch(classifierSlice.actions.updateOpened({ opened: model }));
   };
 
   return (

--- a/src/components/UploadMenu/UploadMenu.tsx
+++ b/src/components/UploadMenu/UploadMenu.tsx
@@ -54,6 +54,7 @@ export const UploadMenu = ({ anchorEl, onClose }: UploadMenuProps) => {
               id: v4(),
               instances: [],
               name: file.name,
+              partition: 2,
               shape: shape,
               src: imageDataURL,
             };

--- a/src/examples/mnist.json
+++ b/src/examples/mnist.json
@@ -35,8 +35,6 @@
     "saving": false,
     "trainingPercentage": 0.85,
     "testPercentage": 0.25,
-    "compiled": "{\"class_name\":\"Sequential\",\"config\":{\"name\":\"sequential_1\",\"layers\":[{\"class_name\":\"Conv2D\",\"config\":{\"filters\":8,\"kernel_initializer\":{\"class_name\":\"VarianceScaling\",\"config\":{\"scale\":1,\"mode\":\"fan_in\",\"distribution\":\"normal\",\"seed\":null}},\"kernel_regularizer\":null,\"kernel_constraint\":null,\"kernel_size\":[5,5],\"strides\":[1,1],\"padding\":\"valid\",\"data_format\":\"channels_last\",\"dilation_rate\":[1,1],\"activation\":\"relu\",\"use_bias\":true,\"bias_initializer\":{\"class_name\":\"Zeros\",\"config\":{}},\"bias_regularizer\":null,\"activity_regularizer\":null,\"bias_constraint\":null,\"name\":\"conv2d_Conv2D1\",\"trainable\":true,\"batch_input_shape\":[null,28,28,1],\"dtype\":\"float32\"}},{\"class_name\":\"MaxPooling2D\",\"config\":{\"pool_size\":[2,2],\"padding\":\"valid\",\"strides\":[2,2],\"data_format\":\"channels_last\",\"name\":\"max_pooling2d_MaxPooling2D1\",\"trainable\":true}},{\"class_name\":\"Conv2D\",\"config\":{\"filters\":16,\"kernel_initializer\":{\"class_name\":\"VarianceScaling\",\"config\":{\"scale\":1,\"mode\":\"fan_in\",\"distribution\":\"normal\",\"seed\":null}},\"kernel_regularizer\":null,\"kernel_constraint\":null,\"kernel_size\":[5,5],\"strides\":[1,1],\"padding\":\"valid\",\"data_format\":\"channels_last\",\"dilation_rate\":[1,1],\"activation\":\"relu\",\"use_bias\":true,\"bias_initializer\":{\"class_name\":\"Zeros\",\"config\":{}},\"bias_regularizer\":null,\"activity_regularizer\":null,\"bias_constraint\":null,\"name\":\"conv2d_Conv2D2\",\"trainable\":true}},{\"class_name\":\"MaxPooling2D\",\"config\":{\"pool_size\":[2,2],\"padding\":\"valid\",\"strides\":[2,2],\"data_format\":\"channels_last\",\"name\":\"max_pooling2d_MaxPooling2D2\",\"trainable\":true}},{\"class_name\":\"Flatten\",\"config\":{\"name\":\"flatten_Flatten1\",\"trainable\":true}},{\"class_name\":\"Dense\",\"config\":{\"units\":10,\"activation\":\"softmax\",\"use_bias\":true,\"kernel_initializer\":{\"class_name\":\"VarianceScaling\",\"config\":{\"scale\":1,\"mode\":\"fan_in\",\"distribution\":\"normal\",\"seed\":null}},\"bias_initializer\":{\"class_name\":\"Zeros\",\"config\":{}},\"kernel_regularizer\":null,\"bias_regularizer\":null,\"activity_regularizer\":null,\"kernel_constraint\":null,\"bias_constraint\":null,\"name\":\"dense_Dense1\",\"trainable\":true}}]},\"keras_version\":\"tfjs-layers 2.8.6\",\"backend\":\"tensor_flow.js\"}",
-    "fitted": "{\"class_name\":\"Sequential\",\"config\":{\"name\":\"sequential_1\",\"layers\":[{\"class_name\":\"Conv2D\",\"config\":{\"filters\":8,\"kernel_initializer\":{\"class_name\":\"VarianceScaling\",\"config\":{\"scale\":1,\"mode\":\"fan_in\",\"distribution\":\"normal\",\"seed\":null}},\"kernel_regularizer\":null,\"kernel_constraint\":null,\"kernel_size\":[5,5],\"strides\":[1,1],\"padding\":\"valid\",\"data_format\":\"channels_last\",\"dilation_rate\":[1,1],\"activation\":\"relu\",\"use_bias\":true,\"bias_initializer\":{\"class_name\":\"Zeros\",\"config\":{}},\"bias_regularizer\":null,\"activity_regularizer\":null,\"bias_constraint\":null,\"name\":\"conv2d_Conv2D1\",\"trainable\":true,\"batch_input_shape\":[null,28,28,1],\"dtype\":\"float32\"}},{\"class_name\":\"MaxPooling2D\",\"config\":{\"pool_size\":[2,2],\"padding\":\"valid\",\"strides\":[2,2],\"data_format\":\"channels_last\",\"name\":\"max_pooling2d_MaxPooling2D1\",\"trainable\":true}},{\"class_name\":\"Conv2D\",\"config\":{\"filters\":16,\"kernel_initializer\":{\"class_name\":\"VarianceScaling\",\"config\":{\"scale\":1,\"mode\":\"fan_in\",\"distribution\":\"normal\",\"seed\":null}},\"kernel_regularizer\":null,\"kernel_constraint\":null,\"kernel_size\":[5,5],\"strides\":[1,1],\"padding\":\"valid\",\"data_format\":\"channels_last\",\"dilation_rate\":[1,1],\"activation\":\"relu\",\"use_bias\":true,\"bias_initializer\":{\"class_name\":\"Zeros\",\"config\":{}},\"bias_regularizer\":null,\"activity_regularizer\":null,\"bias_constraint\":null,\"name\":\"conv2d_Conv2D2\",\"trainable\":true}},{\"class_name\":\"MaxPooling2D\",\"config\":{\"pool_size\":[2,2],\"padding\":\"valid\",\"strides\":[2,2],\"data_format\":\"channels_last\",\"name\":\"max_pooling2d_MaxPooling2D2\",\"trainable\":true}},{\"class_name\":\"Flatten\",\"config\":{\"name\":\"flatten_Flatten1\",\"trainable\":true}},{\"class_name\":\"Dense\",\"config\":{\"units\":10,\"activation\":\"softmax\",\"use_bias\":true,\"kernel_initializer\":{\"class_name\":\"VarianceScaling\",\"config\":{\"scale\":1,\"mode\":\"fan_in\",\"distribution\":\"normal\",\"seed\":null}},\"bias_initializer\":{\"class_name\":\"Zeros\",\"config\":{}},\"kernel_regularizer\":null,\"bias_regularizer\":null,\"activity_regularizer\":null,\"kernel_constraint\":null,\"bias_constraint\":null,\"name\":\"dense_Dense1\",\"trainable\":true}}]},\"keras_version\":\"tfjs-layers 2.8.6\",\"backend\":\"tensor_flow.js\"}",
     "history": {
       "validationData": null,
       "params": {
@@ -81,14 +79,12 @@
           0.6647058725357056
         ]
       }
-    },
-    "opened": "{\"class_name\":\"Sequential\",\"config\":{\"name\":\"sequential_1\",\"layers\":[{\"class_name\":\"Conv2D\",\"config\":{\"filters\":8,\"kernel_initializer\":{\"class_name\":\"VarianceScaling\",\"config\":{\"scale\":1,\"mode\":\"fan_in\",\"distribution\":\"normal\",\"seed\":null}},\"kernel_regularizer\":null,\"kernel_constraint\":null,\"kernel_size\":[5,5],\"strides\":[1,1],\"padding\":\"valid\",\"data_format\":\"channels_last\",\"dilation_rate\":[1,1],\"activation\":\"relu\",\"use_bias\":true,\"bias_initializer\":{\"class_name\":\"Zeros\",\"config\":{}},\"bias_regularizer\":null,\"activity_regularizer\":null,\"bias_constraint\":null,\"name\":\"conv2d_Conv2D1\",\"trainable\":true,\"batch_input_shape\":[null,28,28,1],\"dtype\":\"float32\"}},{\"class_name\":\"MaxPooling2D\",\"config\":{\"pool_size\":[2,2],\"padding\":\"valid\",\"strides\":[2,2],\"data_format\":\"channels_last\",\"name\":\"max_pooling2d_MaxPooling2D1\",\"trainable\":true}},{\"class_name\":\"Conv2D\",\"config\":{\"filters\":16,\"kernel_initializer\":{\"class_name\":\"VarianceScaling\",\"config\":{\"scale\":1,\"mode\":\"fan_in\",\"distribution\":\"normal\",\"seed\":null}},\"kernel_regularizer\":null,\"kernel_constraint\":null,\"kernel_size\":[5,5],\"strides\":[1,1],\"padding\":\"valid\",\"data_format\":\"channels_last\",\"dilation_rate\":[1,1],\"activation\":\"relu\",\"use_bias\":true,\"bias_initializer\":{\"class_name\":\"Zeros\",\"config\":{}},\"bias_regularizer\":null,\"activity_regularizer\":null,\"bias_constraint\":null,\"name\":\"conv2d_Conv2D2\",\"trainable\":true}},{\"class_name\":\"MaxPooling2D\",\"config\":{\"pool_size\":[2,2],\"padding\":\"valid\",\"strides\":[2,2],\"data_format\":\"channels_last\",\"name\":\"max_pooling2d_MaxPooling2D2\",\"trainable\":true}},{\"class_name\":\"Flatten\",\"config\":{\"name\":\"flatten_Flatten1\",\"trainable\":true}},{\"class_name\":\"Dense\",\"config\":{\"units\":10,\"activation\":\"softmax\",\"use_bias\":true,\"kernel_initializer\":{\"class_name\":\"VarianceScaling\",\"config\":{\"scale\":1,\"mode\":\"fan_in\",\"distribution\":\"normal\",\"seed\":null}},\"bias_initializer\":{\"class_name\":\"Zeros\",\"config\":{}},\"kernel_regularizer\":null,\"bias_regularizer\":null,\"activity_regularizer\":null,\"kernel_constraint\":null,\"bias_constraint\":null,\"name\":\"dense_Dense1\",\"trainable\":true}}]},\"keras_version\":\"tfjs-layers 2.8.6\",\"backend\":\"tensor_flow.js\"}",
-    "data": { "val": { "size": null }, "train": { "size": null } }
+    }
   },
   "project": {
     "serializedImages": [
       {
-        "imageCategoryId": "513655a7-1042-4ccb-88e1-f2098c76d958",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAmdJREFUSEvtlb9LamEcxh8tRNTBP0DEwEGSDMVfkyBIiSEO6mSloI0qOCiCIJYOWmur4K9BpXAzhHIIRNoaGiSktqDJ0EEnL+97r+Gly/Ucraa+cIZzDuf7eb/P+zzn5QCY4huL8wP8bLV/JP2gKI/Hw8nJCdxuN2QyGSqVCoLBIAaDASP1GUsqEolgNBpxfn4OuVwODoeD6fR3osrlMsLhMCMoI6BQKMTd3R0UCsX7FMViEc/Pz1Cr1bDb7YjH48jlcgunZARsNpvY2dmhzQg4m82i0WjQez6fj1KpBJPJBKlUislk8l/oQuDGxgb6/T6Vj+xXKBT6SzqVSoVIJIKDgwPk83kcHR2tBoxGo3Siy8tLOJ3OD81arRYsFgt9fnV1BZvNthqwUCjQ1W9tbeHh4QEajQZer5c21Wq10Ol0WFtbewfu7e2tBvR4PHSPXl9f8fb2BolEQvdtNBqBOHdWw+EQp6enyGQyqwHJFLe3tyD5m1UymaQS+3w++P1+iMViur+Hh4ef49Lt7W0QaYmspNrtNshEZBHEnQKBAOl0GmQhi2qhS+cbEMeS6+bmBolEgubv6ekJFxcXqNfri1j0PSvgfEcC2N3dxf39PQKBAHq93tcB9/f3Qf40JJupVArHx8eMYEtNyOVyad5I9oiUJDLj8fjrgC6XC9VqFS8vLzCbzXh8fGQMW2rCbrcLvV5PI0BOCbbFyjS1Wg0OhwPr6+vY3NxkbJT5RbECEieSs5Bp5v41PWOgUqmkRxMJu9VqxfX1NVs12eXQYDCg0+ng7OwMsVhsKdhSplma9OdDxpKuCpp9/wsa/u4BrNHtvwAAAABJRU5ErkJggg==",
@@ -98,10 +94,11 @@
         "imageId": "bc931fee-fcc9-4fd0-abfc-f0c7ed9faa0e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "495ca1b1-58c7-4b56-9c60-cc06f83249be",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAOpJREFUSEvtVUEOwyAMCz+DlwEvg58xuRITQiEEaHeoZmnqYTSuHScYIir0Q5g/4d1ub1tqrSXvPeEJxBgp53z9JGwRhhAuMg7OOZF0mTCl9FU1UmIMyvJQE/YWiradEoIMyrQ4VljK2m54hBBpRDI55ceEsBLJBJDOmkQuQPgQ/H8cmr4ANxozMtRQp7QlHPUUFlcnblMozeE7CKUF8FgPpX5KIzEMTbtZpL70G2hbYZ/C0Q3Qn9sODZfEvpjmDDca7ByuLutaeNa/6eBr7r4VsikhDszUaoLSWru12rT3orqHJwVn775f4QcL6p0Bgz9xpwAAAABJRU5ErkJggg==",
@@ -111,10 +108,11 @@
         "imageId": "2f19c705-9bff-4ba2-bbf0-ff017c4c4b7b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "495ca1b1-58c7-4b56-9c60-cc06f83249be",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAcVJREFUSEvtlj2PQVEQht8rKpVCoREaEhqFUoiv5JIo1ZIbEoWGgihUQolGQ8FPkPiIaAgajYpE5R/cVkPCZs7GRjZbnCN7NrvJTnlyMs993zkzcxUAd/xgKP/A73b791qayWTQ6/Ww2WzQarUwGo1eEs+l0OPxYDwew263Q1EUnM9nJJNJrNdrYSgXkLLG43G0220sFgvkcjnsdjt0u130+30hKDfwkdXr9WI+n8NisbAjo9EoF0jZE4kEs5giGo1itVpxQ4UVUmaTyYTJZIJgMIhOp4NCoSAPaDabGYheLNkqHbhcLhEIBD4URSIRodfKbSkpGw6HCIVCuN1uDEhtEQ6Hue2ki9xAp9OJ4/HI+vB+f18wuq7DarXKATocDsxmMxSLRQas1Wrw+XyoVqtoNpu4Xq9cYG6Fn7NNp1OoqsoUu1wunE4nucBKpYJGowGDwQCas7wT52WFzzUlS8vlslyFz0C/34/tdisXSJbW63VWw2w2i8FgIA+YTqeZhW63G/v9HrFYjLUITwjXkGC0li6XC2t8TdO4YUKN//j6w+EAm82GUqnE5qloCClMpVLI5/PsF+OxnqQCRZN/dV9I4Z8EvgGLrrUBy7/i6AAAAABJRU5ErkJggg==",
@@ -124,10 +122,11 @@
         "imageId": "e3cfca09-038a-4ef3-bca3-92c49003f7ae",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "21bc3a0b-f0b2-4b79-be6f-a4f15694ca4d",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAXZJREFUSEvtlT2rglAcxh+NoK9hQy1NEQ1OUs5NjQ61tjs1CEJj0B4NtmcGTQ1BIBQNbYEK9TEaVPRyAofu1esRK+6Fzng8Pr9znv8bAyDEGxfzAT7b7UyW6rqO5XKJZrOJwWAAlmURBAHm8zn6/T7V3aiA2+0W9XodpVIJvu+jUCigWCyCYRiEYQjP87BYLCBJUiqUCng4HNBoNH6IRUDywTAMdLvd/MD1eg1BEO6v+75eAjyfz6hWq7E3/wDjbElNmk6ng/F4DI7jEmNomiYURcFut8ufNESBZJ+qqqhUKg+CUQxt28ZkMsF0On0OkKhsNhu0Wq1YINl0HOfuxGw2+xWaain5u9frYTgcolwuP4hFnSbavFwuGI1G0DQtEUoFpCn8iHA8HsHz/PuA1+sVsixjtVrF1y7NPMzyQkKxLAu1Wu0DTM7mP22p67rY7/dot9uvjSEZzLfbDafTCaIovr4snjaAU5tjxgNUnSajZv5e+q+BX1jG8QHdY6oHAAAAAElFTkSuQmCC",
@@ -137,10 +136,11 @@
         "imageId": "6ff2c2cb-51af-4dbe-a710-4460dc9f95bf",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "a71b0fa8-d6ca-460b-b161-668bb831fc6a",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAaxJREFUSEvtlLHLAWEcx78UGaVQjDYlg4jFP6DkykrqZpQykMkgBsWfIDfokmQ0WDAoUrLdbJGbheH0PPW+vRN3z3neyW++u8/z/d7n91gAaPjHsXyBn277I5Xm83kMBgPUajW02+2XZzQN9Hg82O128Pv9qNfr/IHpdBrT6ZSmikQi2O/3fBOu12skEgkMh0MUCgVo2ustM1VpKpWi6axWKwRBwGw2e+sYM9Bms2G5XCIWi6HX66FSqbyFkQeYgYFAAIqiUAiBbrdbfkBi5mKxQDAYxGg0giiKuF6v/ICZTAaTyYQC3G43VFXVBWOqNBwOY7VaweFwoFqtot/vvzXz72kM/8NGo4Fms4nL5QJSrdExBLTb7dTMaDRK03W7XaM8Y5YWi0Va4el0orfK+XzmB/R6vZjP5wiFQpAkCeTCZhndlZIKO50ONpsNkskkHo8HC09/pUQSl8sFIk2r1WKC6V4LIke5XMb9fkc8HsfhcOAHdDqdOB6P8Pl8dNmz2SwzTFfCUqlEL+fb7YZcLofxeMwXSBLJskytJHaaHd2WmgX9vP8FfqrJ3+88AX2kqQEWrY5bAAAAAElFTkSuQmCC",
@@ -150,10 +150,11 @@
         "imageId": "8d159cf5-7bf9-4294-9538-aa546fbe5058",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "a71b0fa8-d6ca-460b-b161-668bb831fc6a",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAbRJREFUSEvtlT/LQWEYxi+nzmTwFU7qDD6A2GxKWSxnUZKS8rcsBpPhTCQSow9gsUgZDyMWGSiDGHwDiw5vz1PnKXU4f96Heuu9y3SO+9d1Xd3X8QB44Ivj+QfydvtvWur1etFsNpHL5RAOh7FcLl8aw0Vhq9VCpVKhkPP5jHQ6jfl8bgr9FZAoazQayOfzEEWRAgRBQLlcRr/f5w8cDAbIZrNPi0+nE1W4WCz4A3Vdx/1+f1pMMlyv13wzlCQJo9EIwWDwCbharRAKhd5ekqsMS6US2u02zctQqGkaMpkMiKXvhgvwdrtBVVX6sxrHwFQqhXg8jkQiwRQeDgcEAgErFn3uGLjf7+H3+9kJEEs/Bux2uygWi0wJyXC73SIajeJyufBX2Ol0UCgU2OLdbodkMonNZmML5shSWZZRr9cpwJjZbEbzdDK2MzQ78q8DrVrFTLkthdPpFLFYjB358XiEoihvK+yVzZbASCSC4XAIUmdGq/R6PVSrVSfRsXctgT6fD+PxGARMgE5axbWlk8mEWUo6tFaruVJn+ywMIPn+Edj1ev0s0PV2kz9aZsgTZttSntAfYW/TAWy/Lz0AAAAASUVORK5CYII=",
@@ -163,10 +164,11 @@
         "imageId": "28d99207-6327-42d8-85e2-c1eb3fbbc26e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "5c521ef9-547b-4f3f-8b26-5ae73cc4d998",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAfNJREFUSEvtlT+IgWEcx79HKSmSkgVZDMpEMdiU2EQxGshAGWSwUEoG2SWyGBixiMFgsEk2RTIqSkqRP7mep+667q6753XvXXd13+15e/p93t/39zzf5wHADT+oh38g327/fkvn8zlkMhlCoRBarRZnAzh3eD6fIRQK0Ww24fF4vhcol8uxXq8hEAhQq9UQCAS+F+jz+dBoNCgkFouhVCpBq9XS9Wq1wn6///QHOFmaSqWQyWRoUZ1OB6fTiWKxSNfpdBrZbJZfYKFQQDwex2azgcFggN1uR71ep5DxeAyLxYLL5fIhlFOHiUQC+Xwe0+kUZrMZSqUSi8XiGSCRSHA4HPgBikQizGYzqNVqDIdD2Gw2JJNJ5HI5ChiNRrBarbher/wANRoNlsslLUaA0WgUnU4HKpUKt9sNkUiEHqLPxGxpMBhEuVym9U6nE47HI6RSKV2TuREHWMQM9Pv9qFarEIvFb+q222243W4WHpiBpJrD4aAzI1eCpM1Th5VKBeFwmH/gy4pGoxGTyYR+crlc6Ha7PwMk6aLX62nSsIiTpe91uN1uoVAoWFh0z98Bkos/GAyw2+1oGLAE95c6JKeVJA1Rr9ejQc6iuy0lrwZ5PYhIcJtMJhbe/TMkUUeuRb/fh9frZYJ9yVJmwquNd1v6Z4CPCb/KAdKvVIQAAAAASUVORK5CYII=",
@@ -176,10 +178,11 @@
         "imageId": "be7075e5-60ca-4460-8ff3-221f9b56a3d2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "21bc3a0b-f0b2-4b79-be6f-a4f15694ca4d",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAptJREFUSEvtlT1IqnEUxh/BAsGGpEGiaIoG0clCKIgc3IWIwkEFhzAKcjJL+9AlRMEhaXBSMFxyVFKJcu3DKN00QhADQSJclOpy/pc3btxbvm++XLhwz6LDn/N7z3POc44EwBv+Ykj+A8VW+9+QVCaTweVyQaVSwWg0ol6vw+fz4eDgoKsggiuUSqWIRqNYXFzE29vPAZdIJHh5ecHGxgaCwSBeX18/BQsCDg0N4fj4GNPT058mnJiYwOjoKCqVCh4eHn57Jwg4NjaG+/t7VtnT0xPMZjNKpRJLqtVqEY/HUavVMDw8jL29Pezu7vYGnJmZwdnZGVqtFnQ63TuMsqrVahQKBSYvfRBVOD4+3huQvnhrawuXl5eYmppiyQYGBrC8vIzNzU32nwM6nU74/f7egFarFZFIBOFwGKurqxgcHMT+/j5sNtuHAXK73QzWbrd7A1IPSSrqo8PhQCwWg1wuf09KUlPvQqEQOp3OHwfr20PDScfZIpFIMC8Wi8UvvSgIaDAYkEqlPiRsNBoIBAJMQs6XXxF5A2dnZ3FycgIyPhfJZBLr6+uoVqtdNwz3gBeQxjuTyTBDc1LSr91ux+HhIW8Yk5/PPfR4PNje3maJ7+7ucHFxAYvFgpWVFfGBCoUCt7e3UCqVoH5pNBr09/czk+dyOSwsLIhboV6vRzabZUl3dnbY2FPk83lMTk6ylUZV842uks7NzTHg4+MjO0fNZpPlPj8/Z0ucgNfX13x53XvIVXh6eoqlpSW2vtbW1tg66+vrg8lkwtHRkXhAqpB6RcFdAvIbTSl5ku7i8/OzeMCRkRFcXV2BbuGvUS6XMT8/j5ubG94w3ragu0eV0KZJp9NsfXm9XkGVCTK+oBK6PO46pWLCeEsqJvQH27YnELisJ60AAAAASUVORK5CYII=",
@@ -189,10 +192,11 @@
         "imageId": "eb91f461-209c-4487-b058-81a00fba153b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "cc50123f-7639-4506-9b30-09e31ffc5864",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAfpJREFUSEvtlL/rqWEYxi+RSZLBr2QwUGJTSlgkGShZMFlMIskfIAoDgywWJauNlFJWSVFKLPIjSlLKppTT89T323GOl6PeTp2Ta3mH537vz31dd8/DAXDDXxTnA2Q77U+kbCcKxkj9fj+i0Sh8Ph/2+z1rYEbgaDSCQqGATCZjDUYaPQTqdDoQYKVSQTwefxuoVCpxvV4fJvMbUCgUotVqwWq1wul0otvt/jFQLBYjl8shEAjgfD6DgH/VHZDL5WI+n0OtVtM6MmWtVkOxWMR6vcblcmGE8/l85PP570TS6TRSqdRzYCQSQblcRqlUQrvdRjAYRCgUoj8dDgf0+300m03MZjOoVCqsVivweDwYjUbEYrHvQafTKQwGw8Ph7hwul0uQSLVaLY7HIzgcDjQaDZLJJI3HbrdTwO12o2fkS3Q6ndDpdOhAhUIBJpMJk8nkNTCbzWI8HqPRaDwsFolEEAgESCQSWCwWtGa73aLX69HBBoMB3b/X62WM/q2nrV6vU5cSiQS73e6uKdkhuULD4ZA6ZNJbQI/HA7lcTvf3JYvFQt1JpVJsNhu4XC66Y1aATE3cbjfC4TAymQx1+ExvOWRqRHZKnDkcjpd3lhUguW8E+Gx3X5OwAqxWq9Dr9R8gTfXfjNRms8FsNtPH+5VYcfgK8vP5/w/8AYQgygFaF3rmAAAAAElFTkSuQmCC",
@@ -202,10 +206,11 @@
         "imageId": "eb69fdac-8f39-4cda-8920-4e5b263a2224",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "cc50123f-7639-4506-9b30-09e31ffc5864",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAkpJREFUSEvtlE9o8XEcx98uXJTWVspBslGLclS4q9nKxQ5CoSEn2kopKTUptQO7+HPY4rKLQnEkBzcpU5KTEicOTFPU8/T91vOU9fCbjee09+V3+PV7v76f9+/9/bAA/MJ/FOsHuO+0fyLdd6L4VqSXl5e4ubnB1dUVWCwWgsEgQqHQ1kN+CcjlcvH4+Aiz2UxBf5ROp+FwOPYLNJlMSKVS4HA4eH9/RyKRwMXFBaRSKfYK5PF4uL29hd/vpyBi/vDwgNlshk6nAz6fj/v7ewQCge9PSGDxeBxkuvl8juvra5TLZWosEAgwGAywXC6hUqnQaDS+DyTT2Gw2vL294e7uDslk8q8pKU6hUMBkMsHJyQljqxlLQ/5PPp/HcDikJanVamumT09PsFgsIE9yKCZtBZ6dnaFer9OTR6NR+Hy+Nb+joyO8vr7SWMmkpVKJibf9HpI22u12NJtNKJVKrFarNUOFQkHfjcdjCIVCWiYmbZxQrVajWq1isVjAaDSiWCyuebHZbGQyGRgMBjw/P8NqtTKx6PuNQI/HQ2tPYiJxfdTp6Sl6vR69FhqNhkb7GW0Eut1ueL1eurrIpB8Vi8Xgcrno3SRX5rNibOm/jEQiEdrtNvr9PmQy2WdZ2yPd5kLuYjgchlarRaVSOSxQLBaj1WphNBpBIpHsBNtamk1OpJUvLy90p0YikcMCj4+PaRvJ3pTL5bShu2qn0uj1euRyOXS7XZyfn+/K2r002WyWLgGygZxO5+GBZKOQ0uh0Okyn08MDv0T48NFvHS7xAd43U9sAAAAASUVORK5CYII=",
@@ -215,10 +220,11 @@
         "imageId": "7a681ef7-05bd-42d7-a4f3-b784a6c36e3e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "5c521ef9-547b-4f3f-8b26-5ae73cc4d998",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAkFJREFUSEvtlU2I6VEYxh9qSkNZTEqNaJaiJjajzEIpxdhNKSuTfGQhRQmbWUjJwoJsfKxmZ4UNNTXZMo1iJprVlFIkM8okitzOv9R15ePiqql76mxOp+d3nvc87zk0ADMccdD+Aw9d7Z9bUpVKhWw2i4eHB1gslpWFOYhDOp2OTCYDrVaLRCIBq9X6b4Gnp6f4/v6mIAcB3tzc4O7uDgaDAcPhcOn09/f3IJNGoyEej+/nkM/no16vo91uQy6Xo9PpLABPTk5QLpdxeXmJVqsFjUaD19fX3Uv69PQEhUIB4jKfzy8JicVi1Go1at3n8yEYDK7tpI2heX9/x9nZGc7PzzEej5fEkskkjEYjUqkUnE4nBoPB7kCZTIZisYhAIAC/378kJBKJUCqVMJvNcH19jWq1uvGdWOuQBMBkMlH3UigUFsTsdju8Xi+4XC48Hg9CodBGGNmwFkjuw+12Uw1NXE6nUwgEAtze3kKv14P0HxlXV1d4fn7eH8hkMqkECoXCBbHRaIRcLgedTofPz09IpVI0m839gUSBwWAgHA5DrVbj4+MDb29viEQi6Ha7+Pr6QjQahcPh2Aq2saS/qxC3JKWTyYRattlsiMViMJvNVEK3HRvbYpXQ4+MjlEolOBwOer3etrz1oVmlcnFxgUqlAjabfRygRCLBy8sLdZ6jOJwDSTLJ0zb/Kbap6053OAeSx5q0zNGA5Kvi8Xjo9/vbmKP27OSQxWIhnU6j0WjA5XJtDdsZ+FeEPzbv5PBHAX8BEcjxAVgKX6cAAAAASUVORK5CYII=",
@@ -228,10 +234,11 @@
         "imageId": "b00c44d6-f02b-4915-969f-1f7d2edb38cd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "cc50123f-7639-4506-9b30-09e31ffc5864",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAjdJREFUSEvtlE9o+XEYx99Yys1lageKmxOnxWmkRPlzcFSkHZbEBcWB/ImUi9hlkqOLkkibm8OakxA5rJUcpjYXuSgH1vdTP23Z1vf73fxOey7f+vZ8ntfn/X6ez8MBsMN/DM4f8Lfd/rP0S0dlMhnMZjNMJhN0Oh3Je3x8hN/vR6vV+vIcY0tPT0/hcDiQzWax2x2+qHQ6jUgkwh4oEokQCASIimq1iqurK0gkEnA4HAKs1WpYr9ew2+0E8iMgl8tFKBRCMpnc33iz2WC5XKJQKKDRaGAymYBSPZ/Pfw50Op0ol8t72HQ6RTQaRaVS+WDZ+7yLiwvc39+zszSVShGFVAyHQxgMBry+vh4Ue3p6glQqxWw2g1KpxGq1YgfU6/Xw+Xzo9/vI5/NYLBYHhVwuF0qlEvlP9bnT6Xy7KxhP6ftqcrmc2CcUCsngqNVqjEaj4wGvr6/hdrtBDdLl5eVBbz8js1ZosVgIQCAQkL6enZ3RWrusgVRf/w2I0WjEw8PD8YAejweUndvtFvF4HIlEghaMSmKsUKvV4vb2Fnw+H8/Pz1CpVORLNxgBT05O0G63odFoyFqzWq3fLuofD00wGEQmkyF16vU6bDYbXWH7PNoKqQG5u7sje5MKHo/HGEa7h5SV1PoSi8UEMhgMcHNzg2KxyBhKS6HX60Uul/tQXKFQYDweHwfY7XZxfn5Oir+8vBBlsViMMYy2pdRTaDab5HGHw2H0ej1WMNpA1tU/OUirh78JfANaYOsBIkNN3wAAAABJRU5ErkJggg==",
@@ -241,10 +248,11 @@
         "imageId": "121db626-bc2c-4aad-9bef-b939c431471d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "21bc3a0b-f0b2-4b79-be6f-a4f15694ca4d",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAArFJREFUSEvtlT9IslEUxh9JG0JSlIasUNFIGowgCULCJhERWqRBGrTBoailoaggjHCLBiG0IAJp0cVFXC1zECWQhkJ0UpGC6A+k9Ac/zgXDjzJ7U5o6IL7Dfc/v3nOf53l5AKr4xeL9Ads97R+N1G63w+FwQK/Xo1qtIpPJYGho6Ft74wQUCoU4Pj6G0WgEn88Hj8djwLe3NxweHsLpdDaFcgJOT09jf38fEomENa4B6fn29hY9PT3tBdKp/H4/rFYra/zy8oLHx0eUSiX09vZCJpPh+fn5SyinE66srGB7e/u94fj4OJLJJDY3N7GxsQGz2YxIJNIeoMlkws7ODvr7++HxeLC6uvremIDz8/PtHWk4HGZiIdjS0hKDicVips6trS2Mjo62D9jd3Y27uzuUy2WMjIxAo9FgeXkZarWa3V3bRTM2NoZEIsEEksvloNVqP6j09fUVi4uL8Hq9rd+hUqlENptlnquvmi1oI1dXV6CNdXR0tAbs7OxELBaDTqf7FBiNRmGxWEDrbm5uEAwGYbPZmGU+q6a28Pl8mJubw+npKWtGNTExgYWFBfb89PSESqUCqVSK6+trFgYkJIo7zkASC/lMpVIxFabT6Ybj6urqwvn5OQYHB7G2tga3280dODAwgIuLCxQKBQwPDzeNLRLN7u4uTk5OYDAYuANpt5eXlzg7O8Pk5GRT4Pr6OlwuF1Mr+fVHI02lUmykMzMzCAQCDaH14qL7pDDnDKQXajlJPqP4oqzM5/P/9aIwoFzd29vD/f09FAoFHh4efgasFwP5kHZOXwcSU19fH+RyOfsJBAIUi0UGpv9G1dQW9GItL6empiASid7NTRYgv9FpQqEQizuKwK/qW8D6BuS/2dlZlirxeBwHBwc4OjpqKqjaAs7Ab3dusPAP2OoEP7z/DwchLRDmaSzFAAAAAElFTkSuQmCC",
@@ -254,10 +262,11 @@
         "imageId": "a1eaa5a8-dc97-4bf2-9b71-91d24aef5dd7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "495ca1b1-58c7-4b56-9c60-cc06f83249be",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAnBJREFUSEvtlT9IclEYxp/EkCQUEhdRhCwjcVFwcBAUnES0qSioRRBalCg3EVwcLSL8hwghVFtKUTa46BIRtEU2OKmDuDjoUtjHOdD91PLe62d/lu9ZLvdw3+d33/e87zlTAN7wg5r6D/zqav9+SVdWViCXyxGLxSAUCvH29rencrkcrq+vadIPDw+4v78fuwAfMry9vYXJZOI0ajQaqNfrSKVSKBQKIO98xAt4cnKCjY2NkX4kW4fDgWazycn8AJyfn0coFKKBEokESqUSNpsNUqkUkUiEeR92Xl5exvPz8/jA/gixWIy5uTnUajVmWSaTQafTYXNzEx6Ph1m3Wq0ol8uTAdmig8EgwuEw80mpVKKV4NLYY6FQKHB6ekobSyQSMf7RaBSBQICLB1bg9PQ0CKBfx8fHsFgszFKv10M6ncbu7i663e5kwKWlJTw+PrKatNttus98xZohH+Dh4SF2dnb48thLOjs7C9J9yWQSpGPJmAzr5eUFe3t7SCQSeH195QTzahq9Xk8bxOVyUcO1tTUsLi4OmBPo/v7+1wCHXTQaDa6urrCwsPB9YyEQCJiSdjodCiMHuUqlotBWq4WtrS3c3NywZsmrpMTB6/UiHo9TM7fbjcvLS2i1WuTzefokIntIztRisTgSyhtI/txut1Ojp6cnbG9v4+7uDmq1emB0jo6O4Pf7Jweurq4im83SO/Jd5+fnyGQyuLi4YNYqlQqcTieq1eqnUN4ZkmhidHZ2hpmZGdZ9IpmbzebJgcRhfX0dPp+PHnnk6vpMXwp8BxgMBhiNRnogHBwcDHC/Bcg54SM+GGsP/xXSH/fjwD9N4N8BKYx7FwAAAABJRU5ErkJggg==",
@@ -267,10 +276,11 @@
         "imageId": "84c8f6d6-1eb8-4f43-bc63-3bbab962dabd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "9bbb0091-996f-4025-b020-44e61e7ca992",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAtFJREFUSEvtlctLalEUxj+LKMEeaA4SB2GEQjQoBynWwMdAEqKXgQ4spCD/AgeiAyEaVCiNGhkNAiuSggwsGhQ0iCLoMSsCkQgtyqhIDPKyN3S4Yufh5XIHl9bsnL32/u31rccWASjgH5roB/i31f6RtERRkUiElpYW2Gw2tLW1Fa3n83mEw2Gk02m8vLx8m42yJHW73RTU39/Pmdrj42McHh5iZWUF5+fnyOVyjD8vsL6+Hnq9HmNjY+jr60N1dXUR7OjoCNlslv5rbW2FSqVi1kmkWq0Wd3d3woGjo6OIRCIlEcXjcfj9flxfX+Pt7Y2uB4NB+Hw+xvf5+RnJZBLkUpOTk/Q/Z4TNzc24vLyEWCzG1dUVdnd3EQqF8PHxgcfHRwb0RZDL5QgEAmhsbMTIyEjRJSsrK/mBLpcLi4uL1HF5eRnkW4hVVFRAo9FgZ2cHTU1NmJ2dhdfr5QaSTUtLS3A6ndSxs7MTZ2dnQnhMPvf391FXVwelUsnkmVVSqVSK+/t7uvni4gImk4nKKNTsdjui0SgGBwexubnJXzQTExNYWFjA6+srxsfHsba2JpSFnp4e6k9U6ujowO3tLT8wlUpBoVCA9JROpxMMMxgMiMVitHCGhoawsbFRtJdV0kKhgM/Pz7KAXV1d2N7eRkNDA20Fs9mM9/d3YUACI1ChEZIG39vbQ21tLc19b28vTk9PS5RhjbAcIIkskUhQ2MPDAywWCy2074wVSKaERCJBJpPB3Nwc5ufnQYbzl8lkMqjVato2DoeDynhzc4OBgQE6LNiMFUiSf3BwwOwjEUxPT6O9vR3d3d0gUZFJROzp6Qnr6+vweDw071zGCqyqqqIVZrVaOQ9YXV3F1NQUZ1S/H8A5S0kPzczMwGg0lkBPTk7oXN3a2qK9KtR4n6eamhoq4fDwMD2TPLBkeJPcsj2yfySp0BuX68cbYbkH8vn//8BfEuszEJS9vDsAAAAASUVORK5CYII=",
@@ -280,10 +290,11 @@
         "imageId": "4afbbcbd-c70c-4432-85d0-004627435213",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "a71b0fa8-d6ca-460b-b161-668bb831fc6a",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAZRJREFUSEvt1D2KwkAcBfCXwsrKTrQWwU5CEAVDUEFNEBs/8AS2FoInsEhh6wnsFDtREQ1itBARsfEOkiJlGnGZgYUtZ8ZNYGGnTvKb9ybzlwC8EeCS/sHfbvujSlerFcrlMlqtFqbTKdPehMHBYIDhcAhJktButzGbzfwFt9stNE2D4zg05e128w+Mx+MgYCKRwP1+RzqdZsLIQ0KV9vt9mKZJ0zUaDRwOB//AWCyG3W5H010uF2QyGWZMKGE4HMZ+v6c1ep6HWq1GN8C6hCq1bRvZbBau66JareJ8PrN6/GeYy+VA7h9JGkillUoFi8WCJgoE7Ha7GI/HFJzP52g2m8x1Cv005LxkWaaIrutYr9fBgI/HA4VCAc/n0z9QURQsl0tEIhEcj0eoqsqFcVdar9fpuZEVOEiuhmEY/ibsdDqYTCYUKZVKsCzLPzAUCuF6vSKVSuH1eqFYLHIN7e+dMY+2ZDJJZ2Y0GsVmswEZACKLGSQfH41G6PV6yOfzOJ1OIh7/LBVSfrzElfBTjPse/knwC3k+pgFX06o+AAAAAElFTkSuQmCC",
@@ -293,10 +304,11 @@
         "imageId": "25f6ffdd-5b14-443c-8dc9-e80c5c85351a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "21bc3a0b-f0b2-4b79-be6f-a4f15694ca4d",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAp9JREFUSEvtVs1LKnEUPQNCWERCICFJK1sZWAtt0cK1RSHirtpkICpBRrVJUHMVWYotzEWJEORaCv8ASze6qoW6aOPXpk0fCBX1uBf0JYROKY/H410YmB8zc8+cM+fc3wgAPvAHS/gP2Gu1/15J+/v7sbW1Bb1ej0qlApVKhampKQQCAVSrVZyenuL+/r6jIKIZRqNRLC4uQhAEfHz8NnZjXSqVMDc3h5ubm7agbQHHx8eh0WgYwOv1Mqu1tTXkcjluarFYIJfLYTAYeH1xcYGFhYWfA66vr2N/f7/JyGazIRKJtDSUSCTY2dnhg4rW7aotw9XVVfj9fgwMDHCP5eVlnJ2dtfSTyWTIZDLM/unpCUNDQz8HpCdnZmZwdHQEtVqNYrHI3zGbzTabut3uJrvt7W1+wR8zbDw4ODiIk5MTGI1GvL6+8jekg1w6PT3NkofDYTidTry8vHQPSB0oFufn55idnW1x6fPzMxsqFAp1BKM+omNBNxPTh4cHvL+/N1l4PB4GFFvfAtzb28PGxkYLw3K5jLGxMbF44hlarVYcHBygr68P6XQaFHSSl2Kwu7uL4+Pj3k6aq6sr6HQ61Go1jkC9XofL5QK5lExDbqZ4dCpRkk5MTCCZTGJkZARarbYlFolEgicNsfT5fHh7e+vepfF4HCaT6ctJolQqcXd3x9fsdjtL23UOG4CUPWL4uYaHh5nx6OgoDg8Psbm52TvAr2alQqFAPp+HVCrtHaDD4UAwGOQ3v7y8xNLSEmdyZWWFt6TJyUmQqci1j4+P3TMk2VKpFLuT9r9CocDnPDkEgRmazWbc3t52Mqn4HNIcjcViPOI+b8DX19c8Y8Xs9t8ebSTZ/Pw8S0lzlX4taKx1kvEzbVE57KjTN2749wF/AQWfJxA5tQsUAAAAAElFTkSuQmCC",
@@ -306,10 +318,11 @@
         "imageId": "96978a2c-8660-43c8-80ce-fb104d7d4279",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "5c521ef9-547b-4f3f-8b26-5ae73cc4d998",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAfVJREFUSEvtlTusKVEUhv9BISoR0WhUGgUdlXg0SglCNESPik48CgqiQy8KEr1IPBuFjiASpUSUovBouFn7xs09OV4n40jOzf2TyWRm9uxvr3+ttTcH4Iw3ivsPfLXbP9PSWq0Gp9MJoVD40BDeEYrFYrTbbej1eohEIn5AlUoFn8+HRqOB4XB4dTKFQoHVasW+8Qam02lEo1F0u124XC5sNptP0JcCKTcOhwMcx8FisaDf738ChkIh5PN5TCYT6HQ6fpaaTCaWHwKazearwEQigVgshmKxiGAwyB/YarXuRlgul+H1elEqlfgDI5EIMpnMXeB6vYZcLkcgEADBH+lmW1CR5HI5KJVKBuz1eshmszgcDmxOeiZdgDabDeTGI90ExuNxlhsSAc/nj4fKfD5n79RqNWv4i6V2ux3NZhP7/f4q+ybQaDSiUCiwn6bTKRaLBSgKanSZTMbuUqn0w6QCgQCn0wmpVArJZPJrwHvWkM0SiQTVahVarfbPUHJiuVyyhZED18Rra+t0OiAnBoMB61fS8XjEdru9ud6XAGlDsFqtj+rldz3wOfEvEVKuw+Hw9wI1Gg3G4zGDuN1u1Ov17weORiMG8Xg87wPudjsYDAbMZrP3RFipVOD3+5+C8SoayiFZSk1O17PiVaXPQv4e9+8DfwFijd8B7aaYxwAAAABJRU5ErkJggg==",
@@ -319,6 +332,7 @@
         "imageId": "ef18bf09-a51b-4e20-b937-ded735338d60",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
@@ -332,10 +346,11 @@
         "imageId": "53313fe6-6fb4-4fbd-8be9-9e27961644ff",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
-        "imageCategoryId": "d33329dc-8e54-4f4e-aed3-023b74d4981d",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAq1JREFUSEvtlT1IqmEUx/8WImYqGH1stYmE4CA1GOhUQyIhSeFgk0PQIGHYJ0QuhbUELQWBkBSRpRhNDoqSH00NWUOTIPlBbRGR4uU8cKWLXd9Xbt6pM77v4fzO+T/nQwCgiv9ogh/gd6vdUFKhUIihoSFYrVaIRCL09vZifHyc5XBzc4PNzU1cX1+jUCjwzqshsKurC4+Pj5DJZCygQCDA6+sryuVy7RvBHA4HTk9PeUE5m6avrw8HBwd4enrC5eUlS+Dl5QWzs7NQq9WYmJjA+/s79Ho90uk0J5QTSBHa29vR1taGj4+PuoCpVAparRZXV1cMXqlUGkJ5ARtF0Ol0CIVCkMvlGBkZQSKRaC2Qot/f30OpVMLlcsHj8bQe6Ha7sby8jKOjI8zMzLQeOD09DZ/Ph4eHBwwODn4vkEalu7u7FpQgLQEajUaYzWYYDAb09/fXgNQkGo0GYrEY+XweU1NTiMfjf62SV5daLBbs7u6CZrJareL5+Rm0hcioO+nbZysWi6B33dvbqwNzAmmlZTIZDAwMIBgMwu/3IxKJsNkko2rPz8+hUChYIuQvlUrZNtrf38fc3NwfUE6g0+nE1tYWwuEwxsbG6jJWqVRIJpPo7OxET08PJBIJk5jkp810dnbWHPDk5AQk6eHhIex2ex2Q9ujOzg7u7u4wPDyMt7e3f+vSi4sLmEymL4Hz8/NYWFhglW1vb7PB5zJOSQOBAAMuLS0xaX/b6OgovF4vayRKiiTkY5zAjY0NrKys1CqkJU5vFI1G0dHRwaBUWalU4sMDJ5AqoOGmq7C4uMguwurqKgsei8Vgs9mQzWZ5wciJE0hO6+vrWFtbY3eP2p7s+PiYVZbL5XjDeANpi5B0k5OTuL29ZW9J8/jVfeSi86qQK0gz/3+AzajFy/cXYooYECX7ccMAAAAASUVORK5CYII=",
@@ -345,10 +360,11 @@
         "imageId": "bc3a7543-f3d1-4bee-9146-70088171fa3b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "513655a7-1042-4ccb-88e1-f2098c76d958",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAnZJREFUSEvtlL9LanEYxh+RkKLFVRCqQcRB0TbBopL8NbgoSoloNDQ1RJsgRW02+B+UlhBUKjgoKJRI4SJKIASJS4GBYNCihdbl+8L10qX0nFP3Tr1wpnN4P+d9nvd5RQDe8B9L9AP8brV/JP1U0YmJCaytrcHpdGJycpK+y+VyWFxcHOgCb0k1Gg1WV1fh9XoxPj4OkUiEt7c/yXK73Tg5OfkUygk4MjICg8GAzc1NmM1mvLy8oNVq0UQPDw+4vr5GJBJBu92GXC7H4+OjcKBMJsP29jZWVlaoydHREfb393FxcdFvurGxgVAohMvLS8zMzAiXlMEKhQJ5dHNzg4WFBTQajXcNt7a24HA4oFKpCMiUGFQDJV1fX0c4HEa1WoXVasXd3V2/F5M5mUzCYrH0PTw8PITP5xMOzGQymJ2dhVqtxu3tbb8R8zEQCECv179bmm8BTk9Pw2Qy4fn5GTqdDh6Ph3zq9XrY29sjKJOald/vRzQaFT7hwcEBrf/fFQwGsbu7C+bx/f09vT47O6NMDquBHo6OjmJnZwfz8/PodDq0iVdXV2g2mxCLxWCSz83NkYfLy8s4Pj4exgOnHH7UhS1RKpUiDxOJBEnNcjisBAGlUinK5TKFnAGZt5VKZRiL3gsCsvAvLS1RA3YU2MO1eAMVCgVKpRLGxsZQr9cpMlyk/P1DvIHZbJaW6PX1FUajEfl8nutw/CWdmppCrVajrYzFYh9GZhid84QSiQTskrCsPT09QavVkqR8izNQqVTSTWVbabPZkE6n+bL4SXp+fk4nrVgs0n3tdrv/FhiPx2G32+FyuXB6eioIJjiHgmlCg/8V4C9FAQMQt1gKfwAAAABJRU5ErkJggg==",
@@ -358,10 +374,11 @@
         "imageId": "9f212346-8a64-410b-823e-4dd80558996f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "5c521ef9-547b-4f3f-8b26-5ae73cc4d998",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAnRJREFUSEvtlbFLamEYxp+DYmkIitogCpGaf0BK2GCDSLMNDmGLSy4uOggO1RCBiqOCErgJogiCGoJIglTSUhg0NjaUqEEoCnX5vktxvd6jHu1euJf7rud87+887/s9z2EAvOMPFvMf+NXT/jdGurm5iWw2C41Gg9fX16Eh/RaFfr8fh4eHWF5eRqfTmR/odDrB5/MRj8dHVqzT6XBzc4OLiwtYrdaR5zMpbDabeHt7g0KhGGooEAgQiURAPmh3dxepVGp+oMViwdnZGarV6ogCm82GTCaD29tbbGxsYDAYzA+sVCrY2toaUSCVSnF1dQWlUgmHw4FcLvdLR3Ea6fr6Oi4vL8Hj8bC0tIRer/fZlIzS5XKhXC5je3ub1b5TA8ViMer1OvR6PcLhMHw+H97fv8cwARBFZLcGgwGPj4/zA6PRKPb392lTAm21WrQpUXp3dwe5XI5AIIDj4+Ox4TSVwr29PSQSCTAMg1KphNPTUxiNRqjVaqysrMBkMuHh4QFarXZiEo4FEsDJyQlVJpFIRm8cw3yOlQBJskyqsUCv14tgMMi+D4ahfkyn04jFYjg/P5/EAytwYWGBJsba2hpt8vT0hEKhQLMxn89Tc9vtdtRqNZjN5omgjxdYgUKhEPf399QCR0dHSCaT6Ha79JxIJMLz8zPdKfHdxwWahjp2pETF9fU1Go3GUC8SzAcHBzS6SIRxqalu6Y8NV1dX6QcsLi6CpMvLywsXHvsO2boUi0VqdPILIr7jWpwUEnUkmMkuVSoV+v0+Vx43hTs7O9QCbrcbJHlmKU4KQ6EQPB4PZDIZ2u32LDxuCmci/HSIk8K/EvgNd770AbD7NnoAAAAASUVORK5CYII=",
@@ -371,10 +388,11 @@
         "imageId": "f7958f6e-9153-4753-a84c-06c8ad53655a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "855a0c69-7fed-488d-96df-381f7d642b23",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAn5JREFUSEvtlj1IclEYx/8itvlVaGB+JLTW1qY4OSSkOLeoW6hLWLNzU5ClgmiDIjobGCpFjqKgo+EQKVSERiRiH/pyDrwXzdu9KfLCCz0gXDjneX73/M/zf64CAEP8wxD8Auet9v8lqUwmw+rqKpxO55gQ5XIZ8Xgcg8FgQqAfnVAsFsPv96PRaGBjYwMLCwsYDocwGAxYW1tjVd3tdiMUCs0G9Hq9ODo6YpIFAgEF8oVQKJweuLm5iVwuB3LKv8EGrNVqeHl5oVtKpRLy+Tyy2ez0wK2tLWQyGSaRyKrX63FxcYFOp4NwOEzXRoFcJ+e9w1FgMpnE/v4+jEYj0uk0n6Ks61MBC4UCbm9vYbfb0W63acGHhwfEYjGcn5/TZ76YCsh1h0Ren8+Hs7MzTubcgITy+fkJl8tFPfhd8AItFgvTNO/v77i8vESxWGRsoVQqQTw3agGVSoX7+/vZ7pBMkuvra6ysrNBW397extvb21gxq9UKnU5HG4rsi0aj8Hg86Pf709uCZNhsNsjlcqRSKfR6vW/lCgQC2N3dpesSiQTdbnc2IFcXEE+ur69jZ2cHZrMZUqn050CtVguRSITX11fa4iSZzM67uzs6P+v1OsgeIjMZbYuLiwgGg1heXh57p5OTE+zt7eHj44P7hIlEAiaTiQIfHx+pLOTtm80mBd7c3ECtVjNAtpMfHx/j4OBg4p4ZS43+xYhEIhOfGraiX2fp09MT7V4yAK6urlibhRW4tLQEh8OBw8NDTvNWKhVUq1Vm0pyenqLVavENGbo+4UPiJ4VCQRc1Gg1tBhLk2/b8/EyfieTkN0vwGn+Wolw5v8B5KzrZNHMnfCn4B+4HJBCav9+iAAAAAElFTkSuQmCC",
@@ -384,10 +402,11 @@
         "imageId": "53049f08-6925-4d7e-8780-fd28ed77404d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "513655a7-1042-4ccb-88e1-f2098c76d958",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAppJREFUSEvtlr9LcmEUx7+WDg2Coa7lUCC21OAitBmYFIRFqNEkYtBgoTiIUCCEg0lR1D+gQgQRFIJBLg4VDQ5CotBQaYSoiaKT4Mt5XhS0N29Xeps62z33eb6f5/x4zr0CAE38oAl+gd+d7d+Ufsjo6OgopFIprFYre/fw8ACVSgWLxYJcLoednR2cnp6iXC7/sxq8Umo2m7G/v8+AvSwUCmF1dbV/4MjICHZ3d2EwGCAQ0Bn/2svLC97e3nBycoK7uzssLi5iY2MD19fXmJmZ6R8YDAZB0bWM0vf8/Iz7+3tUKpW2PxKJQKfT4f39HQsLC4jH4x+gnCk1Go2gFLUio/qsr6+jUCh0iFF04XAYIpGI+b1eL7a2tvgBl5eXcXh4CJlMxoDRaLTdHN1KdCiTycTciUQC8/PzeH195Qes1WoYGhpim66urjA3N4dGo9EhMjg4iO3tbbjdbnYoqunY2Bjq9Tr/Gh4fH8Nms7GNBwcHsNvtH0R8Ph9cLlfbf3Z2hqWlpU+buGcNx8fHkU6n2WaKlsSr1Sp7lsvlrCuVSmVb/PHxEVqtFk9PT/0B6Tokk0mIxeJPBVovisUipqamkM1me67l7FKHw4GVlRVMTk72FAoEAnA6nZwH4wSSAjWGXq+HQqFoC1IzEYA6mO7i7Owsbm5uvgfYrSIUCtlkoRQSjCZQLBbjhNGCL0XYrbS2toajoyPmTqVSmJiY+BKsbyDN1c3NTQbx+/0d14KLzCvCgYEB0Kjb29tjtaOa0exsXRUuGO8IJRIJSqUS0yWIWq1GJpP5Cqe9hleEFFU+n2ebb29vodFoeMF4RTg8PIzz83NMT0+j2Wyyz8/FxcX/A9I9vLy8ZACPx8N+JfoxXintB9C958eBfwCpHP0BPUHsrwAAAABJRU5ErkJggg==",
@@ -397,10 +416,11 @@
         "imageId": "dcf08ce8-4553-462b-adf8-a52f17c3607e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "21bc3a0b-f0b2-4b79-be6f-a4f15694ca4d",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAArFJREFUSEvtlT9IcmEUxh8zUBAsCIckHFpECpr6M0g2qBglBUE0lVJKg+FSIE5K6BQUBC5GooMQFjRkGlRQEJJiNbhEk0uQVIRTYOLHecFLYehrn3xDfAfkvpd77/PzOee85xUBqOAfhug/sNXZ/h0pnZmZwf7+PiqVCnZ2dmC324VENe2QxGQyGRN4eXlBPB6vyXpPTw/C4TDGxsaQSqWg1WqbB6pUKiQSCajVaohE9D/BHNzd3WF4eBjlclkQFYvFODo6gtFo/Dnw5uYGAwMD3/aQVCpFqVQSnq2vr8PtdrP7HzssFAro6urC/Pw8Tk5O0NbWhlgshoODA2xvbzO37e3t8Hg8cLlcLAtvb28YHx9HOp1uPqVVYG9vL/L5PBPo7OxkVxJWKpVwOp1YXV0V6js1NcUcfg7upqkCqWkODw8FDYlEAoPBAJ/Ph/7+fqG2lIloNFpTgqaBkUgEVquVCVH3bWxsYHBw8Ivw0tISQqHQt/XmBm5tbWFlZQXv7+8MQL/NzU10dHQwYWqa09NTrK2t4eHhAR8fH38HVCgUuL+/FwBVtefnZwQCAXi9Xq4pyO2Q1Kh2ZrP5i/DExASSySQXjF7iAsrlcvj9fiwvLwubnj6mexpdtCV4oyGQxhQ50Gg0TJPWJpOJra+urjA9PY3X11deXmOHZ2dnbCY+Pj5icnISuVwOwWAQCwsLDDI0NIRsNtsaoF6vZ/Pz6emJuSIYhU6nw/n5OVvPzs6yacMbdVNa3QokSMLV+Azc3d2FzWbj5dVPKdVoZGSEpbOvrw/FYrHG4dzcHJupvFHX4cXFhXCWkWgmk2G6VMvR0dHW15AmPTVId3d3jQE6/xYXF3F8fMwOYt5ouC1oOzgcDlgsFtC5d3t7i+vra+zt7eHy8pKXI7zXENi0YoMPfj/wD9+dKhCihDcxAAAAAElFTkSuQmCC",
@@ -410,10 +430,11 @@
         "imageId": "77f889a1-762d-4afb-b2c3-6a5badfab7d1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "fe3a0e65-964a-4fe4-a026-2cfddd7d2143",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAktJREFUSEvtlblrYlEUxj8VFRdiEcXKSrBNOi1SCLFVcUMEFQlCsBTFJE2KgGARTQoRRMQFrCzEQgRB7dTKRtBC/AskRNQUUbNwbxEyQ6LPmAzMMAcePHj3nd8939lYAF7wB431VwKVSiWSySSOj49hNptRKpU+1exbInS5XMhmsxRitVp/FqjT6ShAKBRiPp/j6OgIvV7v5yKMx+Pw+XwU4PV6kclk1pbgTpImEgkK4XA4qFarMBqNeHp6+n4gi8XC6ekpbm9vweVy0Wq1YDAYcH9/v7HBvhShSqXCYDCgzlerFfR6PWq12kYYOfAlYC6Xg9PppIBAIEAjZWpbA+12OwqFAoisZ2dniMVieH5+ZsrbLkK1Wo1yuQyZTIaHhwdoNBr0+33GsK0lTafT8Hg8WC6XcDgcaxv8s1swlpTH46HT6eDg4ACTyQT7+/tvPiUSCfh8PsbjMV5e1u8CxkCRSITpdEohpA0uLi5gs9kgl8uptAqFAvl8HsFgEHd3d7tPmuvra/j9/o35ury8RDgc3g0oEAgwGo1oNL/bbDbD4+MjpFIp/dRsNkHm6045TKVSODk5+cXHcDikspIBcHh4SFuFWCgUQjQa3Q1Yr9eh1WrfnCwWC7r3SNTn5+cwmUzY29tDo9GAxWJ5y/VH1I1FQ8ZYt9sFkfW9kZHGZrPpQyS9ubnB1dUVfV9nG4HkZ7Jy3G73h34qlQoikQitXCbGCCgWi0Gqj8xNYiQKktdisYh2u71xJb2/CCMgk5szPfMfyFQpxuf+fUlfAaHb6AG/fN9TAAAAAElFTkSuQmCC",
@@ -423,10 +444,11 @@
         "imageId": "a752ec56-7099-4ad5-8839-41a90b409490",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "a71b0fa8-d6ca-460b-b161-668bb831fc6a",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAQdJREFUSEvt1EGqRlAYBuD3XwDJBqyBDC1BKWTGEpQysQQGYhFGJLEDGSllDcrMxALkz61/cu+t29E9Z+SMz+k55/2+77wAnGC4Xg/432nfilSSJAzDAFmWsW0b0Z1ugZqmoe972LaNuq7pg1mWwff9B/w16ls1ZB6pqqoYxxFN08A0TfpNc43DNE2oqgqO49AHwzBEkiTsuvQadlEU2YH7voPjOBiGga7r6Ed6ged5QhAEIuzaTDwWPM9jXVccx8EGtCwLZVmiKAq4rkv/hR8wz3MEQfCAPxIgbprPPxpFEeI4ph9p27bQdR2KomCeZ/pgmqbwPO8LXJaFPkgsfDtAXMMH/CuBN6hdlAEyUYn+AAAAAElFTkSuQmCC",
@@ -436,10 +458,11 @@
         "imageId": "4d30f8d5-b674-42f1-9350-c23eb5c79936",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "5c521ef9-547b-4f3f-8b26-5ae73cc4d998",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAdJJREFUSEvtlbGrgVEYxp+PDBYGi8hgpigpZVIikVCKRQwGWSwyMTHJZDIolI1YRKRMbBiUkgX5Awwiyr2dU2zX/e71fYbbfefT8zvP877nPQyAD7yxmH8g12n/R/o0UZfLhXg8jvP5jHA4jMPh8G0HfhUpwzAwGo3odDqQyWQUotFosFwu+QG63W602+2H+GazgVarxfF45B6o1+tRq9WgUCiQTCZRLpepM+KQTf0oUgKZTqcQiURwOBzY7XbY7/f8AFUqFRqNBu2dz+ejkVqtVvT7fUwmE5jNZjYGwcqhRCJBr9eDyWRCPp9HKpWi4mRCi8UistksMpkMd8BSqYRoNIpCoUCFT6cTFa9UKgiFQvD7/Wg2m9wAiYNYLAaBQAC73Y7BYPAQJgMTiURgMBgwm81eByqVSiwWC0ilUip2u91wuVzQarUwGo0QCARgsVi4A94f9PV6xWq1olCPx0OjVavVIAuAFOlhOp1+3eFXCkKhkMaby+Wg0+ngdDrR7Xb5A96Vh8Mh95E+u/bfB5K35/V6uZ3SZ5EGg0HU6/X3AclfuF6vUa1WkUgk+J9SuVyO7XZLl4DNZuMfKBaLMZ/PMR6P6YpjU6x+CzZCbM+8HfgJxY7QAVKlqTMAAAAASUVORK5CYII=",
@@ -449,10 +472,11 @@
         "imageId": "1feb2999-9fd3-484f-975e-62e9dee34a95",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "513655a7-1042-4ccb-88e1-f2098c76d958",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAhFJREFUSEvtlT/I6VEYx7/EpPyJUgwGCzsGgxJlMKJksChlMEhSlH8ZlLIZKCVlMtiYDKT8mRB2GSjFJvmTt3PK273vzftzL9f0PuPpnO/nfJ/zPM9hAbjijcH6Ab462z8pfXVG8VBKQ6EQHA4HNBoNWCwWrtcrlssl4vE4yuXyX12KERiNRpFMJsFms/8QPh6PMBqN6PV6D0O/BWq1WjQaDYjFYmQyGbRaLSrM5XLhcrmo69VqRaGLxeIh6F0gn8/HeDyGQqGA0+lErVajqfw1ZrMZ1Go1KpUKvF4viGOmuAvU6/Xodrv0vEQiwXa7/dQi6ZVKpVAqleh0OnRdJpNhvV4z8e4XjUgkwmQygVwuR6lUQj6fx2g0ooICgQC73Q7D4RA6ne41QKJCoPV6HQaDAefzGafTCdVqlVaqx+P5dNNut2G1WrHf7//d4e0kcWO322Gz2WhbcDgcCIXC34T7/T4CgQAGg8HzwK8K5ALE8S38fj/MZjMikQitZKZg7EMmgdt7vg3odrvptHkbkFQqedu3A30+HwqFAtMLPDa876mQxie9yePxnm98xqsCsFgsaDabFEom0+FwYDz2VJVms1kEg0Gk02nEYjFGGNnwFHA+n0OlUqFYLNK5Spp/Op1+C34KuNls6NdFIpVKIZFIMLp8CTCXyyEcDuNyufx/IPmATSYTiNtH4imHjwC+7vkAd2DfAWg7Z44AAAAASUVORK5CYII=",
@@ -462,10 +486,11 @@
         "imageId": "d03570e4-fc38-426c-ad10-3481da260465",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "495ca1b1-58c7-4b56-9c60-cc06f83249be",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAsJJREFUSEvtlj1IqmEUx/+iVBAZ9KGSZkMYFRk0BELQEripQ6BYixT0NehQ0BAUklOLDkEmaUaLIk6CNEjODuJSQxBhUEMNQn4MUeblPFylNz9ejXsvl8s948t5nt/z/z/nnOcVACjhD4bgP/BXu/33WSoSidDf34/19XUm1mw2Y3h4mCP8+PgYe3t7eH5+5jWkpsL29naUSiWIxWLEYjGo1Wrejc7Pz2GxWHjzqoBOpxMzMzMoFApoa2vD1NQU6ADFYhEvLy94eHiA3++vbLy5uQm5XI5vA0nZx8cHnp6eoNVqmZ2jo6PIZDIIBoMcBR0dHUgkEpiYmPg+cGVlBdPT03C5XLi+vm5o0cLCAgNRHB4ewmaztW4p74qfCbOzswiFQujr60M0GsXi4iKy2Szv8pbbYmhoCKurq1heXmYwisnJSV43yidpCFQqlWxTg8FQqVSNRgOpVMpRcnl5iVwux74lk0mcnZ2x4qoVdYFjY2PMKoK2Gul0Gg6HA6enp1VL6wKpPaxWK2dBPp9HJBLhtEU5gXpVr9eDHKB2ur+/x8jICN7f3zl71AXSNBkYGGDJvb29kMlkrAVSqVRDwQS8uLhAV1cXxsfHcXNz0xywVRs/5x8cHIAGwuPjY9WVtFylzRzk6OgI1M8UQqHw9yqkiqZh0NnZCRrqGxsbrQG3t7dZg9/d3fGKU6lU7J67u7tZLtUAjcjP0dBSiUSC29tbeDwebG1tNQTOz8/D7Xajp6eH5a2treHk5IS9Ok0DyX9q4rm5Oezv77Pq+6rUaDRiZ2cHg4ODFWUE83q97BH4GrxFYzKZsLu7y14M6sO3tzfOHvRmlgvj6uoKOp2OTZlaMFrICyzfhd1ux9LSUk1bfT4f4vE4wuEwXl9fG1rfFJCdTCAA/W4oFIrKy073GwgE2DT5elf1qE0DeUu0yYR/H/gDzm8PEEF/Y5oAAAAASUVORK5CYII=",
@@ -475,10 +500,11 @@
         "imageId": "a44506c1-38ea-455e-bf42-a970efe9d9c3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "855a0c69-7fed-488d-96df-381f7d642b23",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAlhJREFUSEvtlTtoIlEUhn+VYKOCgggKmtqQJoIWYhGw0cIHBIyNBExhkUYIWPkChUBsJI1iIdgJIhZaJGWQPLCwkBBTBBQbUSQEEUVRl3sLiezqzE7WrXLgwjDce75zz/z/HB6AJf5j8H6A/7rbPy1ddXRvbw9arRZCoRDX19doNBrIZDK/dXx/fx9yuRy1Wg1utxsSiQSvr6+4ubmhe1m11Ofzwev14ujoiPMnFQgE7IGFQgFOp5Me+Pj4wGAwoM/9fh/FYhFGoxE8Hg8HBwf0/Xg8Ri6XWxX38vKC29tb9sCTkxPk83l6wGQy4eHhgfNNWbXU4/Egm83i6uoKoVAI8/l8d0ClUol6vQ4+n4/Dw0N0u13OMFaiiUQiCAaDqFQqsNls34KxAiYSCfj9foTDYcRisd0DibrMZjP14Nvb2+6B5XIZFosF1WoVl5eXa8BWq0Wt8TfBqNLz83Ok0+k/5my327SQs7MzLBYLVlxGIDG0w+GgS6fTgZiYGFwmk0GhUFBIqVQCsc5oNGKEMgI3ZVCpVLBarUilUnTL8fEx7u/vdwckmS8uLpBMJtHr9aDX69HpdHYHtNvtdAKQmxLrBAIBRthWH4rFYkwmE8xms7VE5I9zenqKeDwOtVqNx8dHquLhcPg94Pv7O62aTAoSZA6SHzdRJJlzJMgeg8FAJwjb2Cia5XKJz89PqkCNRrNaJDGxwPPzMwWz+W5fi9kIJDInHiSz7ms8PT0hGo3i7u6O7aXW9m21hVQqhcvlgkgkWgGazSam0ykn2FbRcM7IcJCz8bkW9Autg+gBvrH3UQAAAABJRU5ErkJggg==",
@@ -488,10 +514,11 @@
         "imageId": "a4aaa935-87ee-478a-9b25-c2a1e12016da",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "855a0c69-7fed-488d-96df-381f7d642b23",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAoJJREFUSEvtlctLqlEUxZcFEqQJNiiKwAJtIjQwHPkHhIE9JjZLbCI5FsGBThOpQcMSBNECdSIGOtNpWBqhRCnNRBFBwgeCr8s+UNj1+XkvFy60wMnnPvt39tpnn8MD0MU/FO8H+Lfd/n8sValUeHp6QrVa5WTCVBVeX19Dr9cjHA7D7/dja2sL+/v7feBKpQKr1YpgMPj1H2egSCRCNpvF4uLiRJXl83msrq5ODwwEAjg8POyDdTod3N/ff/uuUCjw8fGBpaWl6YB8Ph/Pz8+QyWRotVqg3Xu9Xtze3qLRaCCTyXwDbmxsoF6vo1AoTAek3p2cnLDFDocDZrN5Ilt7gybu4c7ODkKhEGZnZ9n609NTuN1uVgEXTQScn5/H4+Mjs7JX7+/vzEqylHr7+vo6lj0RcG5uDna7HUajETMzMwOT0qHR6XTweDwjoRMBPzMsLCzg4OCAndK1tTX2eX19HTQqpHa7zUagWCwOhXICDspCwGQyCdoMyWAw4OrqihtQo9GADonT6UQikRhp0fLyMt7e3iAQCFicxWLB2dkZN2C5XGY23d3dYW9vD93u8DeaZvPi4oKdWtL5+TlMJhM3oMvlwvHxMVuk1WrZfTlMNCZ0V6rVahaysrLybdB/Xzewh73Al5cXKJVK1Gq1PqZEImEnky5oUqlUwubmJsihYRoIpEX0ElBCUjQahc/nQywWg1wux/b2NsRiMY6OjiAUCr9yRyKRr0o5AT+tvLm5AY9HexqvZrPJend5eTkyeORY2Gw20G+YaO6oarKQ7tZ4PD52ZyOBdKXRQ7u7uwupVMqSpVIpPDw8sKconU4jl8uNhfQG/PHgc6IB+AFydWxs/C8kDgAQVB5epAAAAABJRU5ErkJggg==",
@@ -501,10 +528,11 @@
         "imageId": "0860711c-4a42-4855-a590-6569f425965b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "fe3a0e65-964a-4fe4-a026-2cfddd7d2143",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAitJREFUSEvt1UGIqVEUB/D/VyyYZomVUTNNkg0LGxYWylJpNFlYUSZZSYosSSk72Shlo6yIncwUiRILC02siChSFlYSpnuLvHnN4zPve/Ve7+7k3vv7zrnnnssA2OMPDuavAG9ubvD+/o67uzvEYjH4fL6Lc3RVhMlkEna7HQzDIJ1Ow+FwcAeazWaKkCjL5TKen5+xWq24AUnqQqEQeDweGo0GDAYDNpvNxRiZyCql1WoVOp2OAsFgENFolBXGCjQajSgWizQ6Mh4fHzEYDLgD397eoNfrKVAqlWAymbDdbrkB7+/vUa/XIRKJKODxeBCPx1ljF6eUnJXX66XAcDiERqPBcrnkBhQKhSDFolarKdDtdqFSqa7CLopQIpFgOp0eAafTiVQqxS04mUwosF6voVAoMBqN6G+BQACtVgulUol+v49Op4PZbPbLjzl7D0mEB3C328FqtSKXy9FNs9ksLBbLEWi327R65/P5lygrkOzy8vJCQVK1crkc+/2PrxtpDM1m8/eBrVYLMpkMYrGYNu/P4NPTEwqFwvUgn8+nT5Db7f5pEwJmMhl6pn6//5hmm812PUhWSqVSVCoVGtnpCIfDyOfzNMWH/8i5fhskyMPDA0hR3N7eHs3PKR2PxwgEArSYvhpni+Z0YSKRoEVzGKdgr9eDy+VCrVb73rU4XU166evrK713tGswDH1ByKsRiUSwWCzONgRWEZ7d7YIJ/8ELksRuyr+f0g/aIuUB3JCMpAAAAABJRU5ErkJggg==",
@@ -514,6 +542,7 @@
         "imageId": "1f57e56b-cf80-4753-8028-f46b22c7355c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
@@ -527,10 +556,11 @@
         "imageId": "6f04ee5d-7250-4020-8ceb-a22f73fcaa44",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
-        "imageCategoryId": "21bc3a0b-f0b2-4b79-be6f-a4f15694ca4d",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAnhJREFUSEvtlT9IcmEUxh9LLKJBHaQthCyUVAgHw0od3WqxbLNwykVEB3NRyQoCaQkcBAdz0KghxSWFxAbRCILGMHXRQcVRLfx4X/iioC+veAmC78Bd7p/nd885zzkvB0AfPxic/0C2q/07Srq1tQW32w2ZTAYOh4N+vw+j0YiLi4uBBRkqQ6FQiFQqBZVKRUEfg/xELBZjF5jNZrGysvKlqNVqxdnZGXtAv98Pp9OJsbGxL0UbjQbm5+fRarW+hTIqqUAgwPPzM/h8/rvY7u4uMpkM1Go1jo6OMDs7i8PDQ+zv748O1Ov1SKfTVOj+/p4apFqt4vX1ld4LBoOwWCx4enqCXC5nF0jKenJy8kn0/PwcJpMJHo+HXt8Fo5J+zPDq6grb29vodDpUd3JykmYtlUqxtraGXC7HLpCo7ezsIBwOU2Gz2YxQKIRer0f7+fDwMDpwamoKd3d3UCqVVIxkl0gkEAgEKGxhYQHxeBybm5vsjcXq6ipub2+/FGy321AoFNRIg4JRD4nI9PQ0fD4f9vb2wOVyP+mWy2WIxeJBLPqcMfCvWrFYxNLS0ifxbrcLrVaLfD4/EDo0kPSMGIWYhGwVkUhEIaSfdrudXaDD4YDX68X4+DgdfolEguPjYwoh28blcrEH3NjYQDQaxcTEBNbX1zE3N/e+AGq1GjQaDUqlEnvAx8dHLC4u4vr6Gqenp4hEIpiZmUG9Xsfy8jJeXl4GwhibhswfMQSPx8PBwQFsNhvIbDabTWqgSqXCCMYYqNPp6PL+eOi+vb3BYDDg5uaGMYwxkLx4eXlJe0cimUxS8xQKhaFgQwGHVv7HB0PP4ajgHwf+ATj59wHG6SdyAAAAAElFTkSuQmCC",
@@ -540,10 +570,11 @@
         "imageId": "a175b07a-b2f5-4b91-8935-9e4a4caca5d5",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "513655a7-1042-4ccb-88e1-f2098c76d958",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAoBJREFUSEvtlT9IcmEUxh/DqMEpbDBEMHPJJVGkSSgXEwch6Y86ROISoSBYWiCISkKF4iBCTjpEDrWkRAg6FzUFJQmGOAj9MYIGUfHjfaGP6oOumQXBd6Z7Xw7P755znnNfFoAWfjBY/4Hd7vbvaalQKITb7YbBYEAwGITT6WyrGR1VaLFYsLGxgYGBAQpptVrw+/3weDxoNpsfgj8NXFhYwM7ODgqFAjY3N/H09IRoNErhQ0NDqFQq3QMGAgE4HA6Uy2XI5XLc3t5S8ZOTE/reVaDJZEIsFsPNzQ20Wi2t8CU0Gg0mJibgcrnQaDS6U2E6nYZarcb29jat8n0QExWLRUbjtDXDra0t2O12pFIp6HS6f4wxOzuLeDyO9fV1kNyPghHI5/NxeXmJu7s7TE1N4erq6o2eSCRCNpsFyVtbWwOZ85eAmUwGk5OTWF5eRiQSeaM1Pj6O4+NjcDgcem40GrG7u/s1YD6fh1gsxvz8PPb29v6KkTYmEgmw2Wx6RrqgUCjw/PzcHeDi4iKSySRGRkYwPT1NjdPf3496vY7e3l4sLS3RfWQKxhkSI3i9XqpTKpUgEAjoM7H/ysoKzGYzJBIJ5ubm6AcxBSOwp6cHq6ur8Pl8YLFYFEqEiTl4PB5OT09RrVYxPDyMWq3GxAMj8EVBJpOBwK+vr/H4+Ii+vj4cHh5CpVKBLP7R0REjjCS0DXyvNjo6iouLC/qbGxsbw8PDw/cCydVEbgebzYZwONwWrOMKuVwuzs/P6bIPDg7i/v7+e4FSqRRnZ2cU8iNApVKJXC6Hg4MDzMzMMF66r8vvyDShUAhWqxV6vR77+/ttt7PjGX6K8C65owp/FfAPxiQDEIZ4RKkAAAAASUVORK5CYII=",
@@ -553,10 +584,11 @@
         "imageId": "a0886d2a-4c21-41e9-83d1-14a102a055f5",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "9bbb0091-996f-4025-b020-44e61e7ca992",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAARBJREFUSEvtlV0OhDAIhOnJ1JOpJ9ObuZkmJITwU9Tsk33ZbKx8zIDQiOiiP572Ad92+7al8zzTuq6EXz77vtO2bWGOt4HXZfdaBr0F1LBlWbpSKMbB//M8TaUloGUjorbWOvA4jg4BDFDrlIAIKGsm1UggJ/EIaNVMK5EJebUcUqiVsYW6TuhQrqOnMgXKIAAgc68hXgFKK7OWhyp5H07oEyq0rMwmzyOgfDn6tmQS/I53P1SYZavVSkcsO3sjeetppAEk8PGHL4FZs1TuDin0gHq6ZIkNW6oDQdE0TeXVFAJ19rwRNCga1OVZ6u08DlSFhQr11NDZjtSrrNDaf9k8zSZROryzANXnH7DqWHr/B1290AH/oPzOAAAAAElFTkSuQmCC",
@@ -566,10 +598,11 @@
         "imageId": "00908046-44ac-4f49-be4f-3285705582cd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "513655a7-1042-4ccb-88e1-f2098c76d958",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAeBJREFUSEvtlLvLQXEcxh9lsMqksGBgsbiMBpOSbBYZlVhRbplEJuVWSibXhc1i4A+gXAdSjEwskvS+/X6D3neQc47D5FtnOuc8n+/znN95BAB+8MERfIF8p/2NlO9EwTpSuVwOg8EAt9sNu91+X8jv96NQKDxdkBXQbDajUqlAKpUiEAig2+1SQKvVwvF4hNVq5Q+o0+kwHA6Ry+VQrVaxWq3u4tvtFovFgj+gWCzGYDDAfr+notfr9Q7zeDwoFotwuVyo1+v8OCSi0WgUFovlnzOZTIZ+v4/JZEKBl8uFH2Cv14NEIoHT6cRms6GiJpMJ2WwWRqMRoVAImUzmKYw8wOjQ2Gw2NBoNCIVC7HY73G43qNVqrNdrukipVEIsFuMPSJSIMIGIRCKQ09rpdDCfzzEajeg3JBeTYeTwkZBWq8VsNqNRt9ttJjxmkT5S8nq9yOfznwOmUikEg0GoVKr7YXpm86VIy+UyHA4HFAoFzufzMxa9/xJwOp1iPB7TXmU6nIEajQYEGIlEkE6nmfK4OwyHw0gkEiAdu1wu3w88HA600kjdsRlOkZLGIQVO4kwmk2x43CL1+XyIx+O0eU6n0/uBzWYTSqUSer2eFYzzb0HqrFarsY6TM5C1rT8v/AKMO8cBWBcFlgAAAABJRU5ErkJggg==",
@@ -579,6 +612,7 @@
         "imageId": "56c5bdd3-a93a-4bfc-b572-1cb886eab9af",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
@@ -592,6 +626,7 @@
         "imageId": "164ef65f-aff6-4576-8280-74c0104114f4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -605,10 +640,11 @@
         "imageId": "208728f5-4880-4553-8e78-b409520f9f40",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
-        "imageCategoryId": "9bbb0091-996f-4025-b020-44e61e7ca992",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAArlJREFUSEvtlj9IqmEUxh8T+6NIpQSRW0FClNSakUUgZQ4OBQVCubSIgyA41BCEUtFQRjRGkRQ0lLqEQ7hHkQaFSkHWEIk0CWWQl3MuRsWnfl3iwr30TCLnvL/3PO85RyUA8viLkvwAv9vtf89SnU6H3t5eNuL29haBQKCkKV+uUC6XY2RkBEajEf39/aipqUFtbS1Dnp+fEY1GsbCwgIODA0GwaKBKpWKQy+VCS0sLHyaRSJDP53F4eIinpyf09fWhrq4OuVwOi4uL2NzcxPX19QewKCDBxsfH4fP53pKvrq5wc3OD2dlZHB8fM6StrQ1arRbr6+toaGjA5eUl2tvbvwYk2MbGBsxmMyfSwXNzc/D7/QwU0sDAAHZ2drjaiYkJ/lxQyQrpbba3t2EymTj+7u6Obz8/P192WshOq9WKi4sLdHR0iAM6HA4sLy9z8NnZGSwWC3eiGJEjhY6VSqXlgQaDAaFQCAqFAvF4nLuSKhSr5uZmJJNJDhcFDAaDGB4e5gS3242lpSWxLI4rWCoK2N3djaOjI1RWVsLpdGJlZUU0rKmpiUeH8mguBwcHEYlESltKMyWTyTiIWp0sLSeaTbvdjqmpKV4GpHA4jKGhoQ+pgl16cnKCzs5OnJ6e8g0zmUxJ3ujoKHdvfX39W9z9/T1aW1uRzWbLAx8eHqBWq7nLxsbGePaKyePxYHJyEo2NjRzy+PiIvb09fnNaDp8lWOHr6yuvrK2tLdhstg851dXV6Onp4e+8Xi+6urpQUVGBdDqN/f19rK6u8uwVkyAwlUpBo9GAbPmcXFVVBb1ez+fRLqUYWtRk6fn5ebmnhiCQHn5tbY1vLiRyIJFIYHp6mpdzLBYrCyoEFF1ttKxnZmagVCrfDiPbaPO8vLxgd3dXNOR9oKhfiz86uUjSD/A73fzd2f/9H+FfV/weEP+tBnsAAAAASUVORK5CYII=",
@@ -618,10 +654,11 @@
         "imageId": "f1b8f6b9-8e2c-4527-81f9-82a2cf05bf95",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "cc50123f-7639-4506-9b30-09e31ffc5864",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAPFJREFUSEvtlEsOwyAMRM3JQk5GOBnJyaimEpXrhmKbtKtYyiIC+THjTyCiSn+McAOvdvu29GpHqWtpjJHwpZRe0Jwzbdv29oj2j3v7vtO6rl8f2QWWUp5AGUiKOI6DlmX5uBMCUvajC6zVtw/cQFjF7dQW0w2EnbDVGm5gA7XmOQOjnnCB13oaOFIonfg5kDfX1FiMlOFcNtbZnMo8U7uUq9PAAHcDZe2wYdpScA3+yFJr7Vo+l0K59rTqXJbKRtF0JnfLrJCrs8LMCmesNNfQulF6Tae2lNdOO3NnUBWQq/PUzdw0HDijztw0o2WgOX8APYGOAZqeDxMAAAAASUVORK5CYII=",
@@ -631,10 +668,11 @@
         "imageId": "92853b74-51eb-4665-acd0-52e90308d3e1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "495ca1b1-58c7-4b56-9c60-cc06f83249be",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAt9JREFUSEvtVj1IcmEUfhwkxbAos8YIqZZqi6BQEYkgIbJaHCKCGlIMoSCIyBAlkGhwC6qhqazox8HFxSWDWmqqoJ+hULQpBaOoj3PAqC+v19tXH9/wneXCe997nvd5zjnPe2UAXvEXQ/Yf8LvV/nclbWlpgdPpRH9/P+7u7nB0dMTPnZ0dHBwcFC1EUQy7urqwuLiI+vr6t8SpVApVVVV4enpCOBzG+Pg4rq+vRYELAlZWVmJoaAhutxsqlQqHh4cYGxsDrZ+enqKhoQHr6+vQarW4ublBXV3d1wFramoQiUTQ2NjISebm5uDz+fD8/PwhaWdnJ7a3tyGXy2E0GkXlFWQ4NTUFr9fLyVdWVjA7O8s1yxerq6sYHBxEd3c3y1soBAH39vZgsVhwfn4Ok8kkCGa32xEIBHB/f881FQtBQKvVirW1NTw8PKCnpwft7e2gRnl8fGSZT05OYLPZ0Nvby2vDw8NcT7Eo2DRnZ2fQ6XScQyaT4fX1o+3m1qhhzGYzLi8vxfAgCKjRaJhFdXV1XkBilclk+F1ZWRkfZmFhgZuL3gmFZIYkcTAY5LrRgSgcDgdmZmaQO6Rer+dS5IuCgM3NzZiYmOC5o6EuLS1lFjmg9wlLSkowOTkJj8eDZDKJpqYmJBKJT5hFOY1oYd5tGB0dZfYXFxdoa2tDOp3+8Pm3A1L23d1dHilShyzxffwIYG1tLY6Pj/Hy8vJpNn8EkBjRSFVUVEgHXFpawvT0NDdCsUFmsLW1ldd9RBmGQiF0dHQgGo1ic3MTGxsbyGazgtg0ElRDtVoNaqDl5WVpNaSrhyzLYDDwcNMBYrEYyLDj8TgUCgXKy8t5dAYGBuByuXh89vf3QT57e3srDTC3u7W1FfPz86CnUqlkX726uuJ7kg5FQ09BFzIZw8jISF4lRCX9XTvyVrqG+vr6WOqcv5Kd+f1+Zka/H1+ytmKbRMo+yQylJJfspX+aPN/3vwCYDksQS6vfSwAAAABJRU5ErkJggg==",
@@ -644,10 +682,11 @@
         "imageId": "044b1140-4b43-450b-ba7d-8a3cbd0436c7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "855a0c69-7fed-488d-96df-381f7d642b23",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAXtJREFUSEvtVVmyREAQLOcYXMNyDss9uAbCNSzXQLgGBzGRPdGieag278X7Uj8zesvO7Moqg4gW+scwHsC/VvuRdKNonueUJAn5vk/DMGzmPM8TY1EUURAEYi4MQ/FrGBDyE9qSWpZF0zStG5umEf9d1yXMXcVXgJIdl0S4yDzP4hJgmKYpFUVxj+GendwtWbZtK4bqut7cB/Lux7Qk7fue8EaIOI5/HMKxVudZQNyyqiqxB4zw/Zu4BAQrgJ0lBS6AN8Kb6cYloG6i3JH5EhDMwNJxHBrHUTCRXgOjLMtW9vtsPGPMviEnlZpQtm2z8h4Copq8Xi8qy5I9AAoAVDeDDwGX5dOTdWWS63Xe8hAQZpV1kJNJLQpfA0JSZCjnPYDBNneKwmnSqMmAWgh5ZQAAHQEqSI/qFoVTQBzUdd3G9DjUNM2VkVpTdQvApS1QxlSv7S0CXyKT1W7A2Yj1IZjK94SEsv2gQ+ybMAeGeRZQ55A7ax7AO2pprX0DicTTAbJdmQsAAAAASUVORK5CYII=",
@@ -657,6 +696,7 @@
         "imageId": "365bd91d-a0be-49c3-944f-4f3a280d42e7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
@@ -670,10 +710,11 @@
         "imageId": "04231c76-badd-43db-9fe8-d4e0c05dd163",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
-        "imageCategoryId": "9bbb0091-996f-4025-b020-44e61e7ca992",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAuJJREFUSEvtlT1IsmEUhu+UtsAoocEhgiKCQskhoxqELEGioYIw3MSMoIIiEqQiyxrEwYYWCfqZ+qEhENSkFgchKvqhH2poiRoqGgIhzDgHCip9fP2KDz74nkV5Oe9zPe997nM/OQCS+Isr5z/wt9XOKGl+fj7Gxsag1WqxuLgIv9//ozNkBC4vL8NsNmN7e5uhHR0dCIfDfwwVAgkQi8UwNTWFiYkJGI1GGAwGJBIJ7OzsMDgej2cFFwIvLi5QWlqK6upqHBwcIBqNora29gNAEk9OTuLy8lIyNC2wrq6OZVxfX0dXVxdeX19ht9uxtrYGmUyG1dVVNDQ04OjoCHq9Hg8PD5KgKYElJSXY3d1FQUEBGhsbEYlEvm1GZqLDEOzm5gbl5eV4fn7OCE0J1Gg02Nvbw+PjI2pqatJKlpeXB4/HA5vNhtPTU7S3t/OvaAmBc3Nz6O3tFW6gUCjQ19eH0dFR3N3dobm5GScnJ2nfEQKHhobg9XozykQF5FrqaSgUQn9/P8hwqdavAWnzhYUFWCwW7imN0PHx8TemEEipQv2RushI09PT6O7uxvX1Nch8X5cQ+PT0BJ1Oh/Pzc6lMyOVylnRmZgYtLS0IBoOf3k0JJPctLS2htbWVkyXVWIhOUFVVxSGRTCY5NK6urj7K0w5+W1sbVlZWuA/kvNvbW8lfSYUOh4MjkUbs8PAwM5AqyN4VFRWYn5+H1WrNCjg7O8sjlRVQrVZjf3+fY40y0+VycXCLFsWeyWTiFDo7O0NTU9MndYThTb3s6elhWG5uLt8Y4+PjQuDIyAjcbjc2NjZAbZHk0q9FlZWVHNZlZWVsBgpzij26mt6/uKioCE6nk0dic3MTw8PDn8zyvmfGC/i9UKVSYXBwkAe7sLCQHwcCAdzf3/P/zs5OVsHn82FgYCC7aBNpVlxcjPr6etD1RWGtVCo53Le2tvgANHcvLy+/B8zKqimKJUv6U1DWPfxngW/HkEgQG/RP4AAAAABJRU5ErkJggg==",
@@ -683,10 +724,11 @@
         "imageId": "456cfa9b-5405-4888-8e2d-f85f484c4a37",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "495ca1b1-58c7-4b56-9c60-cc06f83249be",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAspJREFUSEvtVk1IYlEU/oREox+ySCKkdoEQBLXJ3GQrCwmCKAJ/QCtyJ0XQJihX4iZ01UZRXLgJVFq0kBBcBEEEQSCCWEEIIgYRpLXQ4dwZH77m2XsOzTAMc+Dhfdd773fPOd/5zpMBqOMPmuw/4FdH++8IqUqlwsbGBubn53F1dYV6/TuvaEz2+vrKjRsRqNVqeHt7Q7VaZb+tTNDDSCSCtbU1tkcmk3GAjUOE5gikUCjg7u4Oe3t7uL6+FsQUBBwYGMDk5CS2trbQ1dUlCDg6Oor7+3vodDp0d3fzLra0tITT01PpgFKIMjY2hpWVFeaNUqnkAAOBAFwuFyqVytcBLiwsIBQKob+/nzuUANxuN3w+H97f39vLodBqhUIBvV6PRCLBQkgkISOSnJ+fY3FxUUpgIFoWcrkcOzs7mJubY89HIhFJrFYrYy5ZPp/Hy8vLr3s4NDSEx8dH3gGfMZfY+fT0hOPjY8Tj8Z+AJXm4vb0NrVbLbSZvHh4eeHNTU1O8d1rc0dHRPqCkxADwer2gizXbbwOcnZ1FKpXiEWl5eRlnZ2fiHo6MjKC3txe3t7dSnYPH48Hu7i4nEEdHR+xdyHg53NzchM1mw8HBAZLJpCTA9fV1+P1+UNmQ5pbLZUxPTzOJEwUsFosgWSPRlgI4PDyMi4sLaDQaTmksFgui0ai0sri8vASx7ebmBkajEaVSqeVGtVrNcjQxMcHVJqmP0+mUrjQmk4kpCdnJyQkoXEJFvLq6iv39fV4ZhMNh2O120TTwckjhzGaz6OvrYxszmQzMZjMbk7eDg4Osg1CuGz2S/iMwh8MhCsZU6uNH1Pj4OILBIGtPbMGPfkiFTi2peY7GFEIC/Eywm28iqDQGgwGHh4eYmZlp2YBjsRhbk8vlWrYiUZY2L+js7ERPTw8T7majz4x0Oo3n52fWKdo1US1t90Cx9f8+4DdjqEgQVNRxhwAAAABJRU5ErkJggg==",
@@ -696,10 +738,11 @@
         "imageId": "5e8771f5-9dae-4f73-bbac-cf2f73a0fb7e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "a71b0fa8-d6ca-460b-b161-668bb831fc6a",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAbdJREFUSEvt1b/LQVEYB/CvxY8Si4WyUPwDiiRJSelu3KwySBYU0x3YpFAoCbukTBYWJRnMrCKzgcHI27n1Lm9578+jd3jPfO75nOd5vqerAfDCB5fmH1S723+jpY1GA6VSSVJxRqMR8/kcWq0Wfr//7beqVdjv95HJZPiLtlotuiDDMBiPx9DpdHA6nbhcLnTByWQClmUxnU6RTCZ/HYXilgYCASyXS+j1eiQSCcxmM7rgd3Xb7RaxWAz3+50eSGZ2PB5htVpRKBTQ6XQEk62opaPRCOl0GoPBALlcDs/nkx5ot9ux2WxgsVhAUrparQQxskF2hbvdDh6PB/l8Ht1uVxQmG6xUKqhWqzifzwiFQjidTvRAArTbbbjdboTDYZB0SlmSWmqz2XA4HGA2m9FsNlEul6VY/F5JYK/XQzabxX6/h8/nw+PxoAdGo1H+b3C73eBwOAQf+LubiKrQ5XJhvV7DYDAgEomAJFTuEgWSWdXrdf7dBYNBuZa4GaZSKQyHQ/4JeL1eXK9XeiCZFanKZDIhHo9jsVgowgRTSqJfLBZRq9XAcZxiTBBURfhxiKjQqAl/HPwCG/emARu2hM0AAAAASUVORK5CYII=",
@@ -709,6 +752,7 @@
         "imageId": "7c997190-93a6-42fc-8f96-4d5877ef6f88",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
@@ -722,10 +766,11 @@
         "imageId": "659dd1b4-00b8-4519-b3cf-77db9b078a47",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
-        "imageCategoryId": "9bbb0091-996f-4025-b020-44e61e7ca992",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAntJREFUSEvtlj+oeWEYxx9GC4VJsZBMpjveSxkQGTBSbnRL/sRiMVsZGJTy34hi8GdTd1N3MDBIMt3EwEz8et46p+Pc4//tN/z6Pdvpfd7n837f5897eABwhL9ovP/A377tX7nS4/EIh8OBnK1er8Pn5yeUSiXYbrc/zvsw0O/3QyQSIQGVSiUglDIejwedTgfe399htVqdQB8Cer1eSKVSIBAISDAEsIH4bbFYoNfrPQ7EwGj7/Z4TwFT4K0CVSgWTyeRE0WAwAIPBQFjs9acU6nQ6iMViYDQaaaDP54Nms0kXh0gkgkajAej7lEIM9PX1BXK5nCjB6kNlHx8fsF6v6RyxFXo8HqhWq/fl0Ol0QiAQgNfXV3pjJpOhK5QZjQ2cTqeg0WhuB6IyvLK3tzeyabPZQKVS4YThOuWv1+tJX2IOu93ubUCpVArFYpHkjLJWqwV2u/3s8LHZbCSHVJvcVTRmsxna7TYdnGpkZs6Y5JeXF+IvkUgIcDgcgtVqPckx6dlzr0UulyOTgjK1Wg2z2eysOuYBEYgVXCgUfvhzArVaLfT7fXJatHQ6fTZvuM725/P5ZNxxHZATGAqFyOiiDIHRaPSsuuVyCWKxmF6Px+OQTCZht9vdpvBWoEwmA7fbDYlEgh512WwWgsHg2cM9pBB7E/sLG1uhUNBViS8DVvVoNLoPGA6HT66UvRtzRL1/uIbf8/mc9B3O2kvGqVAoFEKtVgOTycS5l/kcjcdj4lsul+H7+/si7GJb4ADO5/PkytiGQFSEIw4n0WKxuAqiHC4+wDiqXC4XmaMOh4O83lggaDjiuH4hrpEfevGvBb07h88EvLb331f4B1cOSxDWUuCpAAAAAElFTkSuQmCC",
@@ -735,10 +780,11 @@
         "imageId": "e8ce2d82-b2a4-45c5-ac04-a0aaef2ccabb",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "cc50123f-7639-4506-9b30-09e31ffc5864",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAjdJREFUSEvtlT+I+XEYx9+SwYIslJTSjcriukmSpJOUJH/PZDRQNxhMFmVRlBhJksliUDco6ZablAGD6K4zUDoMUn59PnXffvzc+fDz+033Xr7D5/M8r+d5fx4PHoAd/qN4P8Bru/1j6bUdxUWW8vl8uN1uWsz9/T28Xi92ux0GgwFsNhv6/f6XhTIDBQIBIpEI9Ho9CNBsNh9N2uv1cHd3h9VqdfT8W6BOp8Pt7S0NvLm5QTgcZrKYdF+r1diAcrkcdrsdDw8PUCgUUCqVTJDfLzUaDWrtMe11qNFoaGWkGxYtl0uk02mEQiHIZDIuhBno8/lQLBb3WKPRCCqVCt1uF7lcDq1WizvfbrcYDod4eXmBVqv9O2Amk8F4PAaplkxiPp//chAOgX6/H5VK5bSlQqEQYrGYXpzP59hsNizO/tGhVCrFYrE4DWTKfnDJYrGgVCqBQD71z4DEEfKugUCAsp6fn2E0GqkzZBGcnNJzO0wmk3h8fOTCyEAR4Hdi3jTHkjw9PcFgMHBHarUaZKqvDuTxeHSXZrNZSCQSmv/j4wPkdzyZTK4PdDqdqFarXOLZbAaPxwPS8SmdbalIJKLbyGQycbkdDgfq9fopFj0/C0gSk07I91PtdhsulwvT6fS6QPLPEY/HYbVaucRkFTabTbokWMXc4dvb296C7nQ6dHBeX19ZWeyWJhIJxGIxkOl8f39HMBgEAa7X67NgzG+YSqUQjUZRKBRQLpdB3u1SMVt6KeAw7he4sugBiVRw6AAAAABJRU5ErkJggg==",
@@ -748,10 +794,11 @@
         "imageId": "531cb826-12dd-4bb3-9e24-e8bbcb38dda4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "9bbb0091-996f-4025-b020-44e61e7ca992",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAnxJREFUSEvtlT1IqmEUx//5AQ7SEiYhVlJC5OKsTYI4hDXUEkg2iYgQ5BBuojnpJhFBEiIZFUFDRaIGQktzGEYIogXp4BKI4Me9nAcMRF99zbjL7T++73nO7znnOR9jAP7gH2rsF/jT2R46pUqlEvf395ibm+u4y/PzMwwGA8rlct87DgWcnp5GIpHA/Pz8l9NqtQqBQACJRIJMJgOj0YhSqcQJ5Q2cmZlBPB6HWq3G5+cnjo+Pkc/ncXZ2BqlUiru7O6hUKoTDYdhsttGAIpEIsVgMa2trzJHZbMbt7W2H09XVVVxcXOD8/BxWqxXNZrMnlFeEs7OzyOVyzMHT0xMDFovFLocvLy8s3QqFAh8fH98DUnRutxsejwfv7+/Q6/U9YeS9DXQ4HDg8PPwecGpqCm9vb+ywz+djYC61gQcHB3A6naMDNzY22BtxaW9vj2WD3tJisaDRaHSZDnzDnZ0dBAIB1Go1rKysIJVKcQI3NzdZ9ZJkMhkqlcpwQLFYzMqeKjCZTMJkMvVt6pGBExMTX5Nja2sL0Wj0Pwem02ksLS19v2iGTWm7LbRaLRsQvdS3SoVCISKRCKgdgsEgdnd3Od9weXkZl5eXuLq64mwJOjywLfb392G321lP0Sy9vr7ugtLou7m5wcLCAvpFxwtI2yGbzTLI4+MjdDpdB5Au4fV6GYxEG6NQKHBmYmCE4+PjeHh4gEajYRvg6OiIDYJ6vY719XVsb2+D9iTJ5XIhFApxbgpeEZKRXC5ni5egJJo6JFq6pNfXV/j9fpycnKDVavXt1YERtk9PTk6ysba4uNjhkEYZfT89Pe0Lav/kDeTljYfRL5BHkoYz+QswXjAQluOPmwAAAABJRU5ErkJggg==",
@@ -761,10 +808,11 @@
         "imageId": "2f9be710-e7dc-401a-a168-6b4243ccaf3e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "d33329dc-8e54-4f4e-aed3-023b74d4981d",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAsFJREFUSEvtVbtLqnEYfszSohK1qGguCKcsdNAiER260NoQNEcKVoMECYKgohXkBQL7A8LBBtGWiIKgoaWhGoKGKAqzhi5UDsY5vC/okPZ5vHSGw3nhg4+P3/c87+X3PK8IwC/8xRD9J6x1t2vaUrFYjPr6enx+fiKbzRbNtWrChoYGaLVaTE5OQq1Ww2Qy4fj4GHq9nom/RsWEEokEi4uLGB4exujoaAFwd3c3UqlUbQg1Gg2cTifGxsbygOl0mivq6uqCSCTKP1VVODAwgLm5OYyPj6Ozs5Ox7u7uEAgEsLGxwa3d2dkBVT87O4tIJFJ5hTMzM/B4PKBWUby9vcHlcmFzcxNPT0/8bWtrC1NTU/xeVUsbGxvh9/thtVrx/v6Ovb09rK6u4vDwMF+BUqnEwsIClpeX8fj4yMmEw+HKKpTJZNyylpaWAiJCbGtrg81mg8PhAM2SOhEMBn9GFoTa39+Pg4MDUGJXV1dQqVTIZDI/Q0g3dm1tDUNDQ9zCeDyO/f39ohqkDCrWYS79s7MzroiCSI+OjgTdsCxChUIBnU7HgJeXl/D5fDCbzWhqasLNzQ3LhRIQCkFC0l1OewTS3NyM3t5exru/v89rMZlMwmKx4Pr6WpBMsKUGgwHb29uQy+UlQZ6fn5FIJEDEFxcXODk5+fafggoHBwdZTxMTEyD3J1KKvr4+UEt7enoEEyByksXKykrpW0qW9PDwgNbWVh6+1+tlR7Hb7RgZGeFZUVAlBHp7e8sW1t7ezt+np6f5DJnE0tJSaUJaKTn3iEajOD09ZTGT0+TmFovFsL6+zpfma3R0dKCuro6TfH19LU348fEBqVRacJAM2e124/z8HC8vLyVn+se3lOZmNBoxPz+P3d1ddo9QKMSu8d0GL5e94NLQLqMtTrut2MYul+Dr+bKEXy2ZoA5rAV4M49+v8DdEuB4Qh7I11wAAAABJRU5ErkJggg==",
@@ -774,10 +822,11 @@
         "imageId": "b6096612-9f9b-470f-a58a-3748a9cefe29",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "d33329dc-8e54-4f4e-aed3-023b74d4981d",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAhhJREFUSEvtlT+I+WEcx98oKYMUkgyIbjBYbCQTyw1IySR13ShsMpBVWYQSVl2dVcrfwXJdpBOREhYlZcBgkOt56nfTL32/587y+z317fsdnu/z+rw/f94PB8AFd1ycfxvo8XgQDodhMBjQbDZRKpVQqVRuKsDVlM7nc7TbbXQ6Hfj9flgsFlSrVQQCASwWi2+BrwLL5TKen5+x3+/B5XKhUqmQz+eh0WhgMpmwXq9ZQ1k3jVwuR7FYxHa7hc/n+30gIajVanS7XbhcLry9vbGCslb45/RCoQCJRAKHw3EfoFarRa/Xg0gkug+QUJbLJdxuN97f3xlDv51SQiCgRqOBSCRyH2AulwOPx6Ojw3TdpNDr9SIej+Ph4YEpDzcBicLT6YRgMHgf4Gg0wsvLCxKJxO8CBQIBlEolHXpi6OPxGKvVCv1+H7vd7iqcVUqtVisd9MfHR+qnHA6H+ikZDz6fD51Oh+FwSDuXPIPBgPqwWCz+CoQRkBg3uaoymQzS6TRmsxmi0Sh9k8Y5Ho+0W4kJ2O12equQb6lUCqFQSIOo1+t4fX1l1jQKhQLT6RROp5NGTtRMJhOq9uPjg3H9yEZGCm02G2KxGMxmMy6XC507olCv1+NwOPw8UCaTgXRkMpnE+XxGKBTC09MTarUaKxhjhWSj0WhENpvFZrNBKpVCq9ViDWMF/Nbpf/mJUQ1/CvZf4U9m8uusT8S83AFKauo7AAAAAElFTkSuQmCC",
@@ -787,6 +836,7 @@
         "imageId": "5492e2c4-4c7c-43be-b1bf-cc47f351c4d4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
@@ -800,6 +850,7 @@
         "imageId": "b16304be-9aaa-439c-a3dc-7d343a4fac94",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -813,6 +864,7 @@
         "imageId": "8f265cde-39f2-43a5-9c16-2a18497122ba",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -826,6 +878,7 @@
         "imageId": "9d535d8b-fb07-498a-8e5b-3ac03666db74",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -839,6 +892,7 @@
         "imageId": "b34519c2-586e-4320-9ae5-eddb5d1db9bd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -852,10 +906,11 @@
         "imageId": "c944ecb5-5e76-45c2-a66e-a961b8dc491c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
-        "imageCategoryId": "fe3a0e65-964a-4fe4-a026-2cfddd7d2143",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAgRJREFUSEvtlb/LcWEYx7/HwB9gkSiL8mNRBouFEYM/wOJHQhmIMlhtykTCYGMxKEoGJZSFRQYWFrIoJSkDT/dV9Czv6z4enuV97+mc032uz/le3/v6HgHADb+4hP/AP3Vbo9FgNBphu90ikUig3+9zGfNSS2UyGXK5HILBIEGSySTd86yXgHa7Hd1u91H/40C9Xo/ZbEbASCSCWq2G4/HIIxAvKQyFQsjn8+Sh0+nkhrEvEg10uVxoNpu43W6wWq0Yj8dcyu6bRANjsRiy2ezvAefzOXQ6HSaTCSm8XC6fU+jz+VAulyGRSLDZbCAIAhQKBU6nExwOB4bD4VO4qJayQ2KxWAjEPHz4IgjY7/ekeLlc/hX6I2Cv14NcLofJZOL2lBtoNpsxGAwglUqphW63m8aCpc7hcCBgtVpFIBB4j8JUKoVMJkPFFosFDAbDozCDXa9XRKNRFAqFnwOZilarBZvNRsU8Hg/q9Tpdi51Lrpaq1WqsVisCsENxV8eet9ttGI1GNBoN+P3+p6kjGsj+CiyslUolOp0OwXe7HbRaLc7n83vGgilZr9dUrFKp0OFJp9MEYatUKiEcDj+FcWfp95bSS9/mkAUBL4wbyGaNRZlKpSIVd2CxWEQ8HhcVb1weMgiDer1eirDpdEqHhc3hR7OUy6Qnm7gVvgPG7eG7YP8G8AsZwQAQgLZjjgAAAABJRU5ErkJggg==",
@@ -865,10 +920,11 @@
         "imageId": "4ee73514-67d9-41a4-9c73-5be7212ea487",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "855a0c69-7fed-488d-96df-381f7d642b23",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAnVJREFUSEvtlb9LamEYx79qoEiDgkOBSjQ41B8g4iCBICEqSpgNQWNBkw4uCm5BZIFLOESSuKooLg6ROAmCEkIgGggKEkgqiOKPvLzvJenmvZ5zKuIOPeM57/l+nu9znud5eQCm+Mbg/QC/utqcS3p8fAydTgeZTIaLiwskEglOOXECikQiPDw8QKFQUEi/30coFEI8Hsfd3R0mkwkjnBNQKBSiUChApVJRYR6Ph+n0d5NfXV3h9PQU1Wp1IZQTkChptVpkMhkqSkpL3BqNRjgcDoxGI4zHY/qu1WpBr9fPJcAJuLa2hnQ6jfX1dTSbTcjl8pmbnZ0dCrZarVheXqbP/X4/3G73H445Aa+vr7G/v08FAoEAnE7nXPlsNhvC4TBub2/hcrlQLpc/BlxaWkK9XqfduQhI3pEzvV6PNtX7YO1wb2+PZv4aFosFqVSKsSs/BCT/5uTkBBsbG7PvLy8v6Rw+Pj5ygrJyGIlEsLu7Oyf8/PyMUqkE0jCkK9kEKyARMpvNdNY6nQ5WV1cxHA4hkUjw8vJCOR6Ph1aBKVgDiRAZB1JCjUaDbreL+/v72eB7vd6vB77P3mAwzBrn6ekJ5+fnODs7W2iSk8P3SsTx2znL5XJ0Ey2K/we4srKCwWCAdrv9z4S/1OHNzQ22t7eRz+fp3vT5fKjVauDz+RCLxTg4OAAZ/q2trVlCnyqpWq1GMBjE5uYmvYZId5I7TyqV0gVN4u31FIvFQJJMJpOf+4dEyGQy/VXkFUgSOTw8RKVSYRpDMDaNQCCAUqmE3W6n19HR0RGi0Shd5NlsFsViEY1Ggy4CNsEIZCPC5cwPkEu1WJ39BZOYEhAdlSJdAAAAAElFTkSuQmCC",
@@ -878,6 +934,7 @@
         "imageId": "d58fe221-735f-450a-9699-c4026946106c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
@@ -891,6 +948,7 @@
         "imageId": "0729e45f-cac8-48a5-976a-80bdcc97eb1e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -904,6 +962,7 @@
         "imageId": "98ad566e-dd2b-4ae7-8749-1507c5296166",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -917,10 +976,11 @@
         "imageId": "f465d6eb-a60f-4e44-a4b8-a079034920b5",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
-        "imageCategoryId": "d33329dc-8e54-4f4e-aed3-023b74d4981d",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAtZJREFUSEvtlj9IqmEUxh+zTPuDRYFENUQIQbUoRSBE1NCfLUSC3KKEFouCqCCQhgQjQS2xsCUIbHCxliQwWsREsGhpKGgIMoiGoKQi4xxQ8nbr0/TeqRdEPz3f+b3nec95PkUAEviPS/QL/Kh2QUEBKisrsbi4iPHxcTw8PECj0eDs7CzjQ8lIUrlcDr1ej4GBATQ1NaGhoYEBIpEIx8fHGBoawtXVVUZQQWBbWxtMJhP6+vo+JSRgIpGAxWLB3NxcfoCBQACdnZ2pZCTj9vY29vb2MDU1he7ubpycnKCjowPPz8+CUMEKCVBSUsKJXC4XrFYrLi4u+LqsrAy0IZVKBaPRiLW1tdyBkUgE9fX1nGxpaQkvLy9pSUnO6elp3N7eoqamJncgVVFUVIT7+/u/JpNIJNjY2OAzrqurw+vr67dQQUkFtwxgdnaWX2q1OiX3V/flBXh6esrVtba24vr6+t9XSMDm5maeVY/Hkx9gbW0tiouLOdnj4yNubm74s0wmQzQa5YahmT0/P88N2NjYyDNmt9tRUVHByWKxGMLhMA+8UqnE5uZmfrpUq9XCZrN92e7UkU9PTygvL88PMHk2lDgYDGJ/fx9VVVV8VtXV1SgsLMTb2xtX3dvbi4ODA8Gm/rJLW1pacHR0hNLSUmxtbWFsbCwtGbkNmTh5Ka2cnaanpwd+vx8OhwOTk5NpsNHRUf6emigJJBXIcVZXV3/WNF1dXSzR7u4udDodOwhVazabYTAY2H3oaRGPx/mdHIdiyNDJzEOh0CcbpJ18O/jJMzw8PMTl5SWGh4chlUpTFTidTiwvL/NorKysoL+/P/Xbzs4Ox/+5vgWOjIxgZmaGW//jorEg/6TnZHKRzOvr66lrn8+HwcHB7IAUTX8pJiYmsLCwwDff3d1hfn4ebrc7LZlYLEZ7ezu8Xi8UCgXLTvOZVYWCPf6DgLyYdzbcX2A2amUU+w69VCcQPIvjsgAAAABJRU5ErkJggg==",
@@ -930,6 +990,7 @@
         "imageId": "359a4980-8fe3-47eb-813d-609c0a251d01",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
@@ -943,6 +1004,7 @@
         "imageId": "02bacf31-59b7-4bfd-9578-a05b889133b0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -956,6 +1018,7 @@
         "imageId": "68fb4501-10d7-489b-ae45-cdfe9738df89",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -969,6 +1032,7 @@
         "imageId": "64857a14-7f75-4e66-8f42-de7356437606",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -982,6 +1046,7 @@
         "imageId": "89843f18-cc4c-4791-a2c9-4721769755b7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -995,10 +1060,11 @@
         "imageId": "029b6eeb-62dc-4a09-aad7-572b2d23bab4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
-        "imageCategoryId": "855a0c69-7fed-488d-96df-381f7d642b23",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAhhJREFUSEvtlT3IaXEcx7+WZ/AykVL0eCkmxa5kMRi8RDbKQpGNwaYssliURckzmJABJYnNYDHIwGYgqxJSPP1/N8+9de9zzznce+ve7q/Ocs6/7+d8f29/EYAb/mCI/gN/dbb/3pQmk0lIpVJKiNPpRCwWw3K5/C5BDzt8eXlBNBqF3W4ngEQigUjE5L6E3+9Hu91+DqhQKOByuUjE4/HA6/US5Hb7Olm9Xg+FQgHT6RSn0+k5YCQSQaVS+RBZLBZYrVYEzOfz2O/3WK/XOB6Pn/Ya75RWq1X4fD7IZDKcz2cMh0NK6Xa7FdTIvIA2mw2dTodgzFGpVKLnkeAFZE7K5TLBHA6HYFff/hgvIKuVyWTCbDYDc/uzGnG55gVkDZFOp0nr7e2Nane5XLi0f/idF9BoNGIwGECtVpNIvV5HKBT6fUCmnEgkkEql8Pr6SqBGo4FgMCgYysvhXZU5ZYOt0+noVbPZRLFYxGQy4Q0WBGSqrHnYiOj1eoJ0u11aY3xrKhjIICqVCmzr5HI5Wm21Wg3xeJxX9z4EZFCxWIz5fA6tVkurTaPRYLPZcKb2YSBTNhgMH7s0m82SY654CqhUKrHb7XC9Xmk+WZq5QjBQLpcjHA7DYrHAarXCbDYT0O12UwNxhWBgq9Wiu/AerDtHoxECgQAOhwMXD4KBbAQymQy56/f7dNmOx2NO0P2AYCBv5U8O/vvAd7Az3AHNFJ4KAAAAAElFTkSuQmCC",
@@ -1008,6 +1074,7 @@
         "imageId": "53907f87-064e-4a4f-9940-e392a76ec9e8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
@@ -1021,6 +1088,7 @@
         "imageId": "091a377a-49a1-41c4-a3b7-65f61cc05fc5",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1034,6 +1102,7 @@
         "imageId": "b778f1ce-7143-40f8-b2e5-1557dc793631",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1047,10 +1116,11 @@
         "imageId": "9cec3ee6-1cd6-42fb-b23d-705faaa234ec",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
-        "imageCategoryId": "d33329dc-8e54-4f4e-aed3-023b74d4981d",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAcxJREFUSEvtlr2rgWEYxi8iipGUko9FUgYzi4wiCxMR2QzKYJEy+UhZyGg1KKUMMlgMUij5SDJYxOLrDzin56kznNL7qvc86pzOPT/dv/vjuu4eEYAPvDFEvw7ocDgwGAzweDxgtVpxPp855/UjHRLQYrFAqVRCJpNhD5RKpZhMJhCLxbDZbOyBhNBqtWCxWN4DVCqV2Gw22G63cLlc7DtUq9VULPl8Hrlc7j3A0+kEn8+HbrfLHuj1etHpdGC32zGfz9kDC4UCwuEwzGYz9SNXCPahRCLBcrkEsYbJZOI9koKBMpkMZH/9fh+BQIA9UC6X43K5IJVKodFosAcmk0mUy2UqmNVqxR7YbrdBxurxeHhh5IGgHer1euz3e8RiMTSbTWFAo9GIeDwOp9OJ4/EIlUqF6XSK4XCI0WiE6/WKWq2GRCJB7+d6vRYGrFQqVAgk7vc7DocDSBEKhYIW0Ov1EI1GUa1WkU6nX4JxjlSj0VAguSI6nQ7j8Ri32w1+v/9b8mw2i3q9TpX6SvDukAgiEonAYDBQJX4F6dLtdkOr1WI2myEYDGK32/EyeYFcGYgHi8UiNTz5ZoRCIbZA3uxPHgjq8B/4bAJ/f6SfLo+1AakUCuUAAAAASUVORK5CYII=",
@@ -1060,10 +1130,11 @@
         "imageId": "b5978dcc-22a2-4d77-a35f-af39a8892865",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
-        "imageCategoryId": "5c521ef9-547b-4f3f-8b26-5ae73cc4d998",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAgRJREFUSEvtls2LqWEYxq9ZCGWjRPZC/AWshJWxsrKRyAKxpciCLBQpilKK2YmsbJWixMJHKTay9VUoViLT89bRnDPDvI4ZdU7z7J7e+7l+733d9/PxBOCEB46nH+BXu/3vWapUKlGr1RCPx5FMJjGdTq+acleGTCYTq9UKbDabgrjdbqRSqduBTqcTLpcLmUwGiUTiogCDwcBgMIBYLKZi6vU6VCrVbUCdTodSqUT99WQygUgkuioQCAQQDAapmH6/D41Gg/V6fXHNO0utViuy2Sy1gA5QKpWi2+2CxWJRa4rFIoxG4/cBiXIul4PZbKYgm80Ger0ezWbzQ+jdGRJVu92OdDp9BhCX8vk8PeBsNgOfz6dt6UfA+XwOoVD4OVAmk6HVaoHD4VDBi8UCPp8PoVCImvd6PXQ6HZxOJ4zH47OgWq2GxWI5z7fbLRQKBYbD4Tvob5Z6PB5EIpGrXUn3o9frRTQafQzweDzCZrPh5eXlOtDhcCAcDoPL5WK/32O5XKJcLqPdbl9NjBxrAoGAijkcDlRmfr//8xqSCFJHrVYL0jxkT9EZb7t0NBpBLpfT34d0AH/G/ADfOnLX9fRLqFKp4Pn5mZo+vIa73Q4GgwHVapVel/5N00gkEjQaDfB4PJA9aDKZUCgUvg9IlMnzglzasVgM5MS6NL6khre48v8DXwEMi/QBN4qKmgAAAABJRU5ErkJggg==",
@@ -1073,6 +1144,7 @@
         "imageId": "7bb5d886-21c5-49ae-b7a3-a770aff5e5ef",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
@@ -1086,6 +1158,7 @@
         "imageId": "949a01dd-7f9a-4cf7-b3cf-0257db0b594b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1099,6 +1172,7 @@
         "imageId": "c565b1f5-ed6f-4582-b733-325edb801ccc",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1112,6 +1186,7 @@
         "imageId": "25c8efd5-7ef5-46ca-8299-4f5e6b64b729",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1125,10 +1200,11 @@
         "imageId": "47ef07f0-67f5-41e9-a139-c787df52da98",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
-        "imageCategoryId": "cc50123f-7639-4506-9b30-09e31ffc5864",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAkpJREFUSEvtls+LaWEYx79+xMakWIiNf8FOsqCUFaUshLIgKbOayUYoexshC792LKyws5bJlBnZ+AuIlLIgK9yeM50Trss5d9y7mqds3vO+38/z432elwjAEf/RRD/AR2f7J6WPzih4p7TVasHpdCKXy2EymaBcLjPOhMNhKBQKKJVKpFIpiMVi+P1+NBqNq87yAhoMBnx8fOB4/GrZ/X6PxWIBkUgEjUYDiUTCidPa29sbXC4XVqvVb9C7QBIcDofQ6XQckFUhcdaJyzWz2Yz393dhQLlcjmQyiXg8zkRD4svlkolQq9ViNpvhcDgwUcpkMkac9m23W1gsFoxGI2FAk8mEXq/HCRGQPKcahkIhZLNZ5lu/34fRaOT2NZtNeL1e4TWkWrBCdBkoGgIOBoMzsct9z8/PKBaLwoGXnrMRntYmkUiAfmxKK5UKCEhpv2Y3L029XofH4+FSVa1W8fr6is1mw6xR2miNhdEapTkWi/2xf28C1Wo1c73p4lAtI5EIdrsdJ5ZOp5lvrK3Xa9hsNozH478D3hszlDa2LQhmt9vx+fl589jdPrx2+unpCZ1OB1arlblIZNPpFHq9/p6P/EfbqVKpVEIwGOR6kyZKIBBAt9t9PNDhcKBWq0GlUnFAn88H6j0+JjilfFrlFvjbQBpf9IrM53M+AQqrYT6fRzQa5YRp+tyaKoIb//QAvXuFQuHsKbo3Vb4FfHl5QSaTOdOgqUMPshDjXcNrEUqlUiGsrxEp5I8wRcPWsN1uw+12/1ugYPUrB34BxasSEBRMS0kAAAAASUVORK5CYII=",
@@ -1138,6 +1214,7 @@
         "imageId": "3a9c5f7c-8ef0-49f2-91b0-2de34267db5d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
@@ -1151,6 +1228,7 @@
         "imageId": "c50a5142-7f94-43ed-842b-6454a0065c41",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1164,6 +1242,7 @@
         "imageId": "1e02ca11-ca74-4505-b516-d53931af6810",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1177,10 +1256,11 @@
         "imageId": "a23d1f5a-cf23-44eb-95fb-dc6010c3172c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
-        "imageCategoryId": "fe3a0e65-964a-4fe4-a026-2cfddd7d2143",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAntJREFUSEvtlk1IokEcxp83PUggeBIPpRYiQgkVCAkJggh2CBRBIjpE5bWD3fw4JKLSyZMSKB7KS6dCERVFCqJLdCgoKMKPhE75cVMEXWZgl3bdXV5f11iWnYsHZ/6/eZ555j8vA6CPTxzMXw2cm5vD9fU1bDYbMpkMJ1+GUvj8/IzZ2Vl4vV4cHByMH9jr9dDv9z8HuLCwgNvbWwq0Wq1IpVJgGAbdbncopawsFQgEcDgc8Pl8FLizs4NEIoGJiQl0Op3xAG9ubkBC02q14HQ6EQ6HhwJ9ncxKIZl8cnKCjY0N3N3dgdjLdbAG3t/fU4Wnp6dYX1/nysPQQLfbDb/fP14gCc3j4yNkMhl0Oh2urq7GC1xZWcHl5SWq1SpUKhXa7fYAcHJykirf29tDIBCAy+X66aZYWbq8vExVPTw8QK1WDxSamZnB8fExtFot/a/ZbEKhUKDRaAzMZQWcnp5GuVxGMpmE2Wz+rohYLEYul6MbIQ6Qe6lUKiGVSlGr1UYDkqR+vBLkbM/OzmA0GlEsFrG7u4tgMAiLxQK5XI63t7fRgD9aShq4x+OhSgwGA15fX2m4KpUK9Ho99zOUSCQolUp4eXnB/Pw8LSQUCvH09ASRSASTyYSLiwv6m06nqcLz83PuQLKS2Mnj8SiQvBpbW1uIxWK08ywuLoLP56NQKNCNLC0t/fLasAoNWR2NRrG9vQ273U5BR0dH9MxCoRAODw8RiUSwurqKtbU15PP50YFTU1M0hcRa8lpoNBoaEBL99/d3eg329/fpBn43WCskRcinRTweB0nnt+7PMPTJymaz2NzcRL1e/3NAzv3sw8KhFP4HsnHg37f0C6JDEhBVKxhWAAAAAElFTkSuQmCC",
@@ -1190,6 +1270,7 @@
         "imageId": "4417cc9f-476b-4a15-834b-9a0f48318595",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
@@ -1203,6 +1284,7 @@
         "imageId": "42531e2f-f0a7-410f-a50f-2730d202eb40",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1216,6 +1298,7 @@
         "imageId": "5b5232e8-41dd-4fda-8369-68fa56c9087d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1229,6 +1312,7 @@
         "imageId": "c5fb8d55-2306-46cc-a31a-ab09f1513335",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1242,6 +1326,7 @@
         "imageId": "4870deb8-2125-466d-8022-88a4b2882cb2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1255,6 +1340,7 @@
         "imageId": "23e65193-85a5-4c23-ad63-b9e6d7be0131",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1268,6 +1354,7 @@
         "imageId": "b9495641-f7d2-4021-b037-2b3fac59da2e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1281,6 +1368,7 @@
         "imageId": "5f225a9a-0fd1-4bf4-995e-b6f719f2fc7b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1294,6 +1382,7 @@
         "imageId": "fc049c95-2564-4cfd-96e4-8e2f989a65a8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1307,10 +1396,11 @@
         "imageId": "ae809868-d2c5-4d54-b456-62021c8e8194",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
-        "imageCategoryId": "fe3a0e65-964a-4fe4-a026-2cfddd7d2143",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAfZJREFUSEvtlT3IqWEYx/9v2Un5GGTA4COLgUyKku+SksWupIxkkUmKQbEZCElKSUkyMEgGSZKU2SCJQVmc032XM53O43nf87zTe42e2/Xr/3uu634+APzCN9bHD5DJdiQSQaFQgNfrxXg8ZjqOLyk1GAyo1WrQaDSYTCawWq3cAS0WCwaDAQ6HAwKBAMxmM6rVKnfAzWYDrVaLdruNUCjECHod+JRSo9FIFd7vdzidTiwWC+6APB4P/X4fdrsdsVgMpVLpbRg5yDqhWCzG8XikEJfLheFwyC3Q7Xaj1+uhXC7ThGyLdcLZbAaTyQS9Xo/tdsuWx06pw+Gg6ZbLJchaPB4PboHBYBCtVguZTAbpdJo1jPXQNBoNkJRqtRqn04lbIIGsViuQtTifzyCLn0wmWe0gq4Q6nQ7r9Rq32w2dTofeLvv9HolEAqPR6O20b0/pC0hUSqVSKJVKdLtdyOVy+Hw+TKfTt6BvA4VCIebzOfh8PiQSCW2uUqmoZjKtCoUC1+uVEfo2kHSKx+PIZrOIRqOoVCq0Ofktn8+j2WwiHA7/XyDRmsvlYLPZ6C1Tr9fh8XjoqnD2PRQIBNjtdhCJRH90kpsnlUrR9EzFSumrmUwmQ7FYhN/vx/P5xOVyoe+QTDBTfQrI1PRfz3+AX7H31/9+u9Lfo0/QAWtC/FYAAAAASUVORK5CYII=",
@@ -1320,6 +1410,7 @@
         "imageId": "c4a9464b-6c7e-47ca-ae57-8049acf61ac9",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
@@ -1333,6 +1424,7 @@
         "imageId": "8811cfe9-88b4-4c13-90e4-e856240e9b72",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1346,6 +1438,7 @@
         "imageId": "89bb4510-9403-4798-9386-d9dbc98fa256",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1359,6 +1452,7 @@
         "imageId": "a3355d33-3a1c-422c-8e9b-e1bbf9aba264",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1372,6 +1466,7 @@
         "imageId": "ca78d1dd-9523-488d-9336-2c78004671e2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1385,6 +1480,7 @@
         "imageId": "66035f5f-b631-4cff-9567-619ce976a087",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1398,6 +1494,7 @@
         "imageId": "66d86eed-3d8b-414d-bc15-861dc537fb0f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1411,6 +1508,7 @@
         "imageId": "b7a43f3e-ac3a-42ec-bd72-5e3052bec447",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1424,6 +1522,7 @@
         "imageId": "019ca647-5222-45c1-acf5-41dc126da969",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1437,6 +1536,7 @@
         "imageId": "28797101-db4a-469d-82e5-b49d666daf3f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1450,6 +1550,7 @@
         "imageId": "9073d919-c811-49a8-9376-a25ef51b82d9",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1463,6 +1564,7 @@
         "imageId": "b968c6c9-e5b0-46f8-8ea4-012cb4d30ab6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1476,6 +1578,7 @@
         "imageId": "d12162d1-1748-451b-a8db-00dd6644c73e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1489,6 +1592,7 @@
         "imageId": "213745a8-b5cb-4080-9612-16abba51af87",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1502,10 +1606,11 @@
         "imageId": "a86b44a9-da54-40bf-a6f6-9ed779512db9",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
-        "imageCategoryId": "fe3a0e65-964a-4fe4-a026-2cfddd7d2143",
+        "imageCategoryId": "00000000-0000-0000-0000-000000000000",
         "imageChannels": 1,
         "imageChecksum": "",
         "imageData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IArs4c6QAAAPZJREFUSEvtlIEKgzAMRNMvs/0y9ctsv8xxjhvBqUnrJoMZEBVqX+7MNYjILBdW+EngNE0yjqPknE97YSqMMQqBwzB8HwhI3/eLwhvo8dv8h/9tKSYYF+LijUyTpYBgcnHXlVIywdVA5pIgKCulLA2grPhUAbuue6kCCIp0zfPzWD5S6gZ6rNPqQ8DW71UN3FKmt8UxCPCeymrgXueEMrd7jZlAbZM1EIASiOet5kwgPmTePIf3R4CeM5JrOKnNlqJjxAFZO1K4zmfz0KBzTt467Hxn6LUTzbHQ06eDf2TzqeDX/D/PWteUejbyrrmBXqfc6y639AEzls0BnWxWywAAAABJRU5ErkJggg==",
@@ -1515,6 +1620,7 @@
         "imageId": "e252e125-f97b-4d4c-992c-dca7bbdbb7fc",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 2,
         "annotations": []
       },
       {
@@ -1528,6 +1634,7 @@
         "imageId": "1e1f2d57-9349-43eb-aeb4-ff456613d6d3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1541,6 +1648,7 @@
         "imageId": "ceb701d4-bf63-4ec7-939d-c7914f973848",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1554,6 +1662,7 @@
         "imageId": "86c96dbc-bcbc-42cf-b022-183d746c52f9",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1567,6 +1676,7 @@
         "imageId": "9ca23b29-217f-4950-89d0-3a5408575733",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1580,6 +1690,7 @@
         "imageId": "114dffd7-1c46-41a9-8f43-882ab043341b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1593,6 +1704,7 @@
         "imageId": "11c0a9c1-11d7-408c-951c-2d84256b3887",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1606,6 +1718,7 @@
         "imageId": "c424a621-c494-4eff-b430-745314c99ddf",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1619,6 +1732,7 @@
         "imageId": "90652da4-aaf8-44c1-bb84-83dcb27145f7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1632,6 +1746,7 @@
         "imageId": "4e5ed9ee-8b06-485d-8aff-84b9aa9d1a46",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1645,6 +1760,7 @@
         "imageId": "62b9b6c4-302e-4384-b3a3-a09f2588abc8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1658,6 +1774,7 @@
         "imageId": "944e30ba-944c-4392-aa28-6192e1f682f6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1671,6 +1788,7 @@
         "imageId": "96372cf5-d937-4d92-aa47-cdcb794cb432",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1684,6 +1802,7 @@
         "imageId": "da6498e2-5c98-48ca-859a-89e6fdb9a92b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1697,6 +1816,7 @@
         "imageId": "7dcdf1be-ca87-41b1-a21c-ab0352d0f31a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1710,6 +1830,7 @@
         "imageId": "99c97a42-0f6e-4312-991b-16b091c4d266",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1723,6 +1844,7 @@
         "imageId": "67129be9-8a53-4963-ba9b-fb6ab415bcf0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1736,6 +1858,7 @@
         "imageId": "aee27262-f9c5-46b4-9b63-e1f1e96e4201",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1749,6 +1872,7 @@
         "imageId": "d2f0d693-ff9d-4ec6-b76f-03ee6094a948",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1762,6 +1886,7 @@
         "imageId": "3db2dd37-ff73-48e3-9350-c2cc96c67020",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1775,6 +1900,7 @@
         "imageId": "297daf61-8a56-41d9-a42b-152b42b871a7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1788,6 +1914,7 @@
         "imageId": "b48f4a94-38fb-4671-bfed-b5264e094790",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1801,6 +1928,7 @@
         "imageId": "a61b5b47-cfbe-443e-9688-d5c4a8f3a681",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1814,6 +1942,7 @@
         "imageId": "b3529f79-27c0-4de5-86c3-040e763ea4af",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1827,6 +1956,7 @@
         "imageId": "7cb39a6f-e20f-416d-9641-63fd2a24939f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1840,6 +1970,7 @@
         "imageId": "4e591cc2-6e2e-4820-8cee-64de44a800b0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1853,6 +1984,7 @@
         "imageId": "19efb80b-e5f9-48bb-bce1-3e78624e889f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1866,6 +1998,7 @@
         "imageId": "8989a694-af10-4c8f-b0e5-138bc0ddce46",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1879,6 +2012,7 @@
         "imageId": "2ee56151-8414-4986-a937-ccf282c2dca1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1892,6 +2026,7 @@
         "imageId": "1e3645cf-f394-4cda-9de9-ced5fe8c0794",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1905,6 +2040,7 @@
         "imageId": "4a4b1d86-7e0b-4e45-ae3e-4c1160da042a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1918,6 +2054,7 @@
         "imageId": "431bdab7-bcc6-4aeb-995a-4380c861f04f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1931,6 +2068,7 @@
         "imageId": "53c49f20-f375-463d-8b64-129334492231",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1944,6 +2082,7 @@
         "imageId": "f50b3287-1e5e-4321-b0d6-04b0b21ec6f2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1957,6 +2096,7 @@
         "imageId": "dd6f3758-a490-4efe-885f-1bc54c67c48f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1970,6 +2110,7 @@
         "imageId": "ec00901d-34cc-4be7-8d2b-c65f1d7786ef",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1983,6 +2124,7 @@
         "imageId": "dc061b9e-2cb9-4b6f-b0f5-cddd97b67086",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -1996,6 +2138,7 @@
         "imageId": "2115644a-2fb2-4ff4-9d32-2ffc4f2cca16",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2009,6 +2152,7 @@
         "imageId": "dd96b09c-c0b5-474c-bc6b-76369237f946",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2022,6 +2166,7 @@
         "imageId": "49e74182-af7e-49ca-95de-81e8c91f6e3e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2035,6 +2180,7 @@
         "imageId": "bcb3218b-11c2-4f0d-b85a-ab4c6eb4bcbd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2048,6 +2194,7 @@
         "imageId": "46aabf76-31cf-468d-9c52-e240a56d16a1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2061,6 +2208,7 @@
         "imageId": "38ddbfde-1cdb-4501-891b-f9b37b29370a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2074,6 +2222,7 @@
         "imageId": "ec51194c-e6ca-414e-9873-533b14de98c8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2087,6 +2236,7 @@
         "imageId": "352b1c39-af9b-45a0-b8f5-3d25c10a00ef",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2100,6 +2250,7 @@
         "imageId": "79a8636a-09f4-4d94-99cf-d2d5505404ef",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2113,6 +2264,7 @@
         "imageId": "26d13fff-6556-4e9b-b169-37b7ab89df44",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2126,6 +2278,7 @@
         "imageId": "7578413a-6bcb-4113-9cc6-060a71033382",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2139,6 +2292,7 @@
         "imageId": "aeab6e1b-d155-4e65-bd2c-8dfcb70ee9d8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2152,6 +2306,7 @@
         "imageId": "3f721184-fbf5-4f4d-904d-6a4ea416f1c1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2165,6 +2320,7 @@
         "imageId": "5bc2cb11-1172-43c6-9814-baf0cc43397e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2178,6 +2334,7 @@
         "imageId": "10adcfb0-6fec-4f74-9fa7-eaf2437917b9",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2191,6 +2348,7 @@
         "imageId": "106fb556-cb70-4485-b299-eb2f5d436c8a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2204,6 +2362,7 @@
         "imageId": "c24fc539-8b20-44a1-9e75-9100e776cb3e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2217,6 +2376,7 @@
         "imageId": "920babbb-b58e-4e2a-b8aa-d1a4835dfc63",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2230,6 +2390,7 @@
         "imageId": "c3597ec4-6ac9-4d9a-ac1d-d606df2e7eaf",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2243,6 +2404,7 @@
         "imageId": "935b81c2-49a0-41d8-820c-c941c4d4a3d6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2256,6 +2418,7 @@
         "imageId": "81d8dd11-9cc8-4062-96c6-1ddfa60e0dce",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2269,6 +2432,7 @@
         "imageId": "c8def80b-9676-4d68-803f-7c000e1c9071",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2282,6 +2446,7 @@
         "imageId": "fc91b040-9762-4f0a-9565-130c2b02b292",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2295,6 +2460,7 @@
         "imageId": "3c3896a2-9329-45db-bc24-5ec7818dd68c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2308,6 +2474,7 @@
         "imageId": "f202f21a-4a5f-4d5d-9101-1d618ef3a3f6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2321,6 +2488,7 @@
         "imageId": "d8c85e8e-d333-42ee-8e43-a84a4e285917",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2334,6 +2502,7 @@
         "imageId": "02d2f1e1-efbc-4232-a43c-916fd6b5c674",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2347,6 +2516,7 @@
         "imageId": "142c312e-007e-4a48-9e7a-c18b8bd9d8d8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2360,6 +2530,7 @@
         "imageId": "52dc9035-d3e2-4a69-b82b-e41f92443015",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2373,6 +2544,7 @@
         "imageId": "cb922f0d-b590-4eac-b3d1-087e864250c9",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2386,6 +2558,7 @@
         "imageId": "399793e5-510b-4187-af15-6b9e9b495106",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2399,6 +2572,7 @@
         "imageId": "d753634f-0262-46c7-9627-876e270cceb7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2412,6 +2586,7 @@
         "imageId": "0f630852-06f1-4f86-a695-79f57e2c8186",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2425,6 +2600,7 @@
         "imageId": "d24dd0f0-d366-48a1-9351-bc58ccea2d2f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2438,6 +2614,7 @@
         "imageId": "cf2dc14c-8d02-4dec-9c2a-10a8b2e8afb0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2451,6 +2628,7 @@
         "imageId": "275c3ec6-a0c0-4776-a32b-e0bf7049f40f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2464,6 +2642,7 @@
         "imageId": "9bae4553-c4e0-4454-97e6-8d8d8a40f61b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2477,6 +2656,7 @@
         "imageId": "1724961d-39bc-4787-a76f-9118f55e89b3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2490,6 +2670,7 @@
         "imageId": "e64545f7-ac6c-44f6-8be0-1d42351ee2a5",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2503,6 +2684,7 @@
         "imageId": "8699453c-30ab-4006-bc97-3f9916128ee0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2516,6 +2698,7 @@
         "imageId": "9c48bfc0-6534-4869-855e-a2b14859ef45",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2529,6 +2712,7 @@
         "imageId": "748a4c38-f696-41e0-8e2e-c5f0000078fb",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2542,6 +2726,7 @@
         "imageId": "54682b9d-c556-4926-aec8-8492686303bb",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2555,6 +2740,7 @@
         "imageId": "0f9f124c-c969-4851-ae28-18ff7438968c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2568,6 +2754,7 @@
         "imageId": "bfe82335-e204-4eb3-8b36-8df29fe08d74",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2581,6 +2768,7 @@
         "imageId": "d81f4314-dbfe-4bc4-a97d-cda56385009e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2594,6 +2782,7 @@
         "imageId": "5f6a954b-736a-49c8-a574-aa0f179f5948",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2607,6 +2796,7 @@
         "imageId": "273ea421-1e93-4c85-b6ba-9851d856ddf1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2620,6 +2810,7 @@
         "imageId": "f78c3946-4aba-4de4-90fa-96e0bba6f4a6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2633,6 +2824,7 @@
         "imageId": "3006f46e-b9b6-49d0-bb3e-b44eeb53f4a6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2646,6 +2838,7 @@
         "imageId": "fcdfd9c5-0878-45d3-ab72-c863ccde10f3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2659,6 +2852,7 @@
         "imageId": "00dbcec1-e3be-4fda-9de5-5bfe817aefe5",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2672,6 +2866,7 @@
         "imageId": "82eb7311-289e-4d4a-83da-5d6b3314f681",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2685,6 +2880,7 @@
         "imageId": "a4404cad-3b76-40d4-aed1-93ca228d2b89",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2698,6 +2894,7 @@
         "imageId": "d80d480a-207f-4463-9f54-cf133981024f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2711,6 +2908,7 @@
         "imageId": "eeef39cb-19b9-4f1f-87d1-55777cb107f8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2724,6 +2922,7 @@
         "imageId": "600b96fd-2b8c-4edf-bd63-86955c38aaf1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2737,6 +2936,7 @@
         "imageId": "fe16cc2a-e362-45fd-a1ae-ff937728f8bf",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2750,6 +2950,7 @@
         "imageId": "ed2f1869-b2f2-499c-94fe-bbd8109c543a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2763,6 +2964,7 @@
         "imageId": "a5fddbb7-6ce3-4d21-8282-71f02f58a328",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2776,6 +2978,7 @@
         "imageId": "4f009feb-741e-48a0-823f-5fd287fff2d7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2789,6 +2992,7 @@
         "imageId": "d458c8a3-9ad8-44f4-85af-9dbe32543f01",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2802,6 +3006,7 @@
         "imageId": "185a4a1c-61d0-415a-bfac-44c7650500cb",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2815,6 +3020,7 @@
         "imageId": "15e4c8a3-08e8-4733-ad2c-8a3c39dc3686",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2828,6 +3034,7 @@
         "imageId": "653dc7ff-7f61-4444-a85f-5dbc4673c346",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2841,6 +3048,7 @@
         "imageId": "0d1daec1-16d6-47b3-afe4-724565e326c8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2854,6 +3062,7 @@
         "imageId": "966acfc4-9a6e-487d-98c0-c97f5bc58e75",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2867,6 +3076,7 @@
         "imageId": "10d752d2-2f71-4fa2-8159-a7a19d99c8f5",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2880,6 +3090,7 @@
         "imageId": "35dfd2f6-70c3-45fb-97bf-4777edd9261b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2893,6 +3104,7 @@
         "imageId": "2bb27090-9621-4ed1-9d2d-6f16db6bfd50",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2906,6 +3118,7 @@
         "imageId": "6d1f0aa4-a691-4214-903a-22e20f2bc54c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2919,6 +3132,7 @@
         "imageId": "6537b8d1-b5b9-48a4-99bc-e46dcc1a6b6b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2932,6 +3146,7 @@
         "imageId": "b9a13c02-d068-4d25-a25f-1051a7acad28",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2945,6 +3160,7 @@
         "imageId": "cb45164c-a901-4449-b12d-b6949314e2df",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2958,6 +3174,7 @@
         "imageId": "2d25fb5b-73ce-44d1-8881-475c8855db30",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2971,6 +3188,7 @@
         "imageId": "c64429c8-5889-43ca-99ae-837dd26c3c02",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2984,6 +3202,7 @@
         "imageId": "3c066910-659e-4afb-ad85-220a752098c6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -2997,6 +3216,7 @@
         "imageId": "8a1fa612-607c-40eb-b847-16c1677bde0b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3010,6 +3230,7 @@
         "imageId": "d41d7628-cf4e-4a8d-ab8f-d164e126f9d0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3023,6 +3244,7 @@
         "imageId": "6b7abcda-1bd2-459d-b774-d67e95b1273e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3036,6 +3258,7 @@
         "imageId": "bb85e70e-c60f-437c-80e2-1f53ea0a5eff",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3049,6 +3272,7 @@
         "imageId": "c3e40d61-b623-4c09-8e18-cdc407346dc3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3062,6 +3286,7 @@
         "imageId": "48820288-1413-4ac2-95f5-f4299f4388f0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3075,6 +3300,7 @@
         "imageId": "4a717c85-49b5-41c0-9cb5-672762567b34",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3088,6 +3314,7 @@
         "imageId": "c688a617-8419-4c65-9ab6-bcb6e3adec72",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3101,6 +3328,7 @@
         "imageId": "7566f750-e387-4639-9827-6f3d288ea7ce",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3114,6 +3342,7 @@
         "imageId": "cbdb1d8e-2d51-459d-a4dd-f434e4fc2227",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3127,6 +3356,7 @@
         "imageId": "350c9859-1c83-4535-90e6-bb4dd48a7dfd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3140,6 +3370,7 @@
         "imageId": "1c9be325-24aa-43c0-b164-ba47f11725a0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3153,6 +3384,7 @@
         "imageId": "6ce11c25-b4d5-4761-95ec-4bcdd6b9f9da",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3166,6 +3398,7 @@
         "imageId": "e61c718f-39ca-4b3e-8fb1-01ebf780f909",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3179,6 +3412,7 @@
         "imageId": "0ed04a41-d36f-431c-8cc3-e2c56cfbd4af",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3192,6 +3426,7 @@
         "imageId": "24fb8972-2cec-4849-8e22-aa81bb838b45",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3205,6 +3440,7 @@
         "imageId": "f1b3fde6-25be-41d2-b6ef-58d02a09215e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3218,6 +3454,7 @@
         "imageId": "ca8dbe57-d8fe-4853-b538-7f7320de931d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3231,6 +3468,7 @@
         "imageId": "bea243ae-625f-4a8b-bc9f-cd397fb7179f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3244,6 +3482,7 @@
         "imageId": "2adbec56-0ae2-4ea4-8404-adfab7a60ff1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3257,6 +3496,7 @@
         "imageId": "710418b0-8f22-44c0-b4b0-06749aa8a4cf",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3270,6 +3510,7 @@
         "imageId": "d1824d22-00af-464e-a60d-abaa8f543cf3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3283,6 +3524,7 @@
         "imageId": "75106a89-40e7-45e4-ac70-9069c5d82044",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3296,6 +3538,7 @@
         "imageId": "cfd9aec8-cbff-4699-bfb1-a440e414a64d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3309,6 +3552,7 @@
         "imageId": "51255059-a77e-4eeb-adf7-1e9473cdf15c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3322,6 +3566,7 @@
         "imageId": "4af46afb-1ade-4a68-9e58-5aed3756774f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3335,6 +3580,7 @@
         "imageId": "44e1e425-d261-4ed7-8b0b-b76b0f143428",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3348,6 +3594,7 @@
         "imageId": "3a31a4ca-0ab9-4058-91d3-8bbd1f843dd0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3361,6 +3608,7 @@
         "imageId": "c59ac669-26d7-4e40-b448-49ec97a48c78",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3374,6 +3622,7 @@
         "imageId": "8787a054-e82a-40e8-a41b-23eb0f7c734d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3387,6 +3636,7 @@
         "imageId": "08ae2f85-22f0-4947-8a5a-c4731a0f5f67",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3400,6 +3650,7 @@
         "imageId": "b5da0474-96ab-4fc3-a92c-61aeba006c2b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3413,6 +3664,7 @@
         "imageId": "b1c51893-571e-4db2-82c4-eecf057150c2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3426,6 +3678,7 @@
         "imageId": "4110ca08-9c30-4bdf-895c-0edc9fc2ff6a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3439,6 +3692,7 @@
         "imageId": "5e89dc36-9de4-42e2-8c38-1fddec2c44ba",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3452,6 +3706,7 @@
         "imageId": "7c1b27f3-9bd0-4fc0-8241-558b955f850e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3465,6 +3720,7 @@
         "imageId": "39765ee8-f0a9-4407-9936-5ba99f17a6b9",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3478,6 +3734,7 @@
         "imageId": "7958ae4d-5683-458f-a212-292fed4f4154",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3491,6 +3748,7 @@
         "imageId": "fd2bfe9a-0b92-497a-9fa8-280ee041295f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3504,6 +3762,7 @@
         "imageId": "d8d606ff-5c08-42ec-8cee-e959eca31ac5",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3517,6 +3776,7 @@
         "imageId": "5b088de6-55bb-4c0a-b265-8572632ba551",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3530,6 +3790,7 @@
         "imageId": "e0ec7fa8-1425-45ed-b32b-23823c9d6a20",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3543,6 +3804,7 @@
         "imageId": "fdca9c98-44fd-4492-afa1-1589e57a8258",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3556,6 +3818,7 @@
         "imageId": "8de7c4b0-ece8-418a-b140-ba424cd4452b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3569,6 +3832,7 @@
         "imageId": "f005d931-a7b4-421d-af92-647e35950fc4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3582,6 +3846,7 @@
         "imageId": "b86cab7e-448c-4662-a1a1-3317d689186e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3595,6 +3860,7 @@
         "imageId": "11ed2d4d-fdfc-4693-8916-e9c73659d59b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3608,6 +3874,7 @@
         "imageId": "2c752a18-8ca1-4da2-861a-efcbad398ca3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3621,6 +3888,7 @@
         "imageId": "c979a567-f755-466e-b2a9-1140ceaa7944",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3634,6 +3902,7 @@
         "imageId": "4b45b617-e58e-4987-b52b-4c052eb052f4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3647,6 +3916,7 @@
         "imageId": "4e6f1fb1-f1e7-45af-a20c-095c649d1405",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3660,6 +3930,7 @@
         "imageId": "69619769-23e1-4d30-a14b-a464e9085fb9",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3673,6 +3944,7 @@
         "imageId": "77875044-afc5-4a68-8885-113beb3ee292",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3686,6 +3958,7 @@
         "imageId": "94a0bc99-7af9-4ab8-90a9-d19329323f75",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3699,6 +3972,7 @@
         "imageId": "e3a0004f-9f3a-4c34-84dc-50cd2b773260",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3712,6 +3986,7 @@
         "imageId": "9ac4d44f-8667-45b0-89e6-04daa7ef0a35",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3725,6 +4000,7 @@
         "imageId": "742989b0-fb3d-4470-90db-9bff5f6b51b5",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3738,6 +4014,7 @@
         "imageId": "429ba18c-4e03-40c8-b92f-3c5937eab1fc",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3751,6 +4028,7 @@
         "imageId": "267d3e28-cb65-4066-ba67-e7399910daaf",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3764,6 +4042,7 @@
         "imageId": "62bedf38-6613-47f2-ba63-8ddd0658b83f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3777,6 +4056,7 @@
         "imageId": "d0bf28da-686e-4619-ac28-606e239ae1c2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3790,6 +4070,7 @@
         "imageId": "14a9de57-2f8a-4120-8fa9-3fb1dd674fde",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3803,6 +4084,7 @@
         "imageId": "ad794250-5fac-4a94-8616-68ceec85e6bd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3816,6 +4098,7 @@
         "imageId": "7dd5d22f-4b55-47f6-988c-2dc62731cdbd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3829,6 +4112,7 @@
         "imageId": "0cc2bece-c246-4a85-8681-76e12e020628",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3842,6 +4126,7 @@
         "imageId": "cafafd2c-3e82-4157-8946-ba4b59e600e2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3855,6 +4140,7 @@
         "imageId": "668a192b-7ea9-48e4-9b08-51c57a90bf2f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3868,6 +4154,7 @@
         "imageId": "1927e8b6-105f-478e-9ed1-1f82ededbdee",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3881,6 +4168,7 @@
         "imageId": "658df407-52f8-4c34-89db-17e8f9843108",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3894,6 +4182,7 @@
         "imageId": "3e01c26d-9519-4e69-ab49-820462a7ae6e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3907,6 +4196,7 @@
         "imageId": "379af352-af96-4e5b-af6c-223b3896e471",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3920,6 +4210,7 @@
         "imageId": "9309b7b7-1956-4492-8305-daa411ddee13",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3933,6 +4224,7 @@
         "imageId": "73420116-47a1-473c-aef3-5a99e71a1f72",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3946,6 +4238,7 @@
         "imageId": "3cae7c19-31f2-45cc-b97d-9965431e7de5",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3959,6 +4252,7 @@
         "imageId": "fd04d9e9-9760-4c22-93b5-221f52ae61a0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3972,6 +4266,7 @@
         "imageId": "9c192065-4f7d-4d94-929c-53e812efa5eb",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3985,6 +4280,7 @@
         "imageId": "90e351cc-89fc-44e5-8c31-6b5baa9edf6d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -3998,6 +4294,7 @@
         "imageId": "1101eec9-4951-4304-9f05-fa38a25753a7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4011,6 +4308,7 @@
         "imageId": "30f4e992-0f54-47f6-83c3-9b342ffeda68",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4024,6 +4322,7 @@
         "imageId": "4d69cac7-3b0f-40b2-b31a-08e77796d2fa",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4037,6 +4336,7 @@
         "imageId": "f965a61f-b055-4fa0-8130-9d849321e8d3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4050,6 +4350,7 @@
         "imageId": "74c22499-f974-44e5-bfcf-286f3d81dbd3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4063,6 +4364,7 @@
         "imageId": "707a7269-79c2-4241-9671-96e876064a4a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4076,6 +4378,7 @@
         "imageId": "53b873ee-5ec4-402b-a621-72fdc7b309b0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4089,6 +4392,7 @@
         "imageId": "6afdfaaf-c4c1-4cc9-b347-dd7069fac40c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4102,6 +4406,7 @@
         "imageId": "e07a282a-f0f2-4eeb-827c-5826299027f8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4115,6 +4420,7 @@
         "imageId": "8a904cc4-2574-4c3c-afd5-f1a315e8df14",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4128,6 +4434,7 @@
         "imageId": "d6f050ef-45c7-49b0-91e0-a956d9979802",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4141,6 +4448,7 @@
         "imageId": "3caee997-92d0-4425-9ce8-966b693bcb0f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4154,6 +4462,7 @@
         "imageId": "849c7aac-5548-4f7d-a9a6-47d955e09128",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4167,6 +4476,7 @@
         "imageId": "67a51722-63a7-4913-9c6e-cb87f18e91aa",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4180,6 +4490,7 @@
         "imageId": "508f4481-6f65-4a7f-86bd-a5db6c7a5158",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4193,6 +4504,7 @@
         "imageId": "1a33edfd-830f-4b3f-8796-59b1f8080a0c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4206,6 +4518,7 @@
         "imageId": "b79b987b-731f-4dcd-831b-f86653729f0c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4219,6 +4532,7 @@
         "imageId": "8b0c7f00-6585-4449-b569-9a485c4e045b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4232,6 +4546,7 @@
         "imageId": "900499fc-9cad-4c9a-8111-b6f2505fe7cd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4245,6 +4560,7 @@
         "imageId": "ff534342-bf59-4bc4-90f6-66e09811be2b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4258,6 +4574,7 @@
         "imageId": "8399a326-37ba-444c-8a28-bb6ff2d469bd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4271,6 +4588,7 @@
         "imageId": "17e891b1-2382-40f5-b24f-93a5ced54b2d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4284,6 +4602,7 @@
         "imageId": "9a4c3a9d-85fd-4a4a-ad11-920fdc38838a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4297,6 +4616,7 @@
         "imageId": "a8e9888c-4688-4621-870e-46b2a2996887",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4310,6 +4630,7 @@
         "imageId": "4f654f6c-bbfc-4956-82a3-a0dc6473ed5f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4323,6 +4644,7 @@
         "imageId": "9728a26e-1db9-4bc6-9854-502864954a4e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4336,6 +4658,7 @@
         "imageId": "2e7d4eb6-83b9-43db-b72f-b6f9e58dd9b6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4349,6 +4672,7 @@
         "imageId": "782fe906-671a-4d58-9382-95aafc46cb05",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4362,6 +4686,7 @@
         "imageId": "8c9206bc-afa1-40e1-87d5-bc58bab5c403",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4375,6 +4700,7 @@
         "imageId": "9a9bff07-988d-4492-861d-87bbb37f961e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4388,6 +4714,7 @@
         "imageId": "3f8b6770-c375-44df-b17a-603ef704c8da",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4401,6 +4728,7 @@
         "imageId": "2d366950-2c26-43bf-967d-ccc4a15218cf",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4414,6 +4742,7 @@
         "imageId": "8457d023-7584-4a58-936e-8c955f95dee0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4427,6 +4756,7 @@
         "imageId": "a1ba7052-3539-4322-b0f4-24921b7e568b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4440,6 +4770,7 @@
         "imageId": "2ddd5e18-4935-477c-86f9-0d9690f1d2c5",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4453,6 +4784,7 @@
         "imageId": "8a15a0d5-f406-4540-b929-16f4f9aff12c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4466,6 +4798,7 @@
         "imageId": "79532e45-a24e-4f8e-a161-1f62886cbf28",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4479,6 +4812,7 @@
         "imageId": "d1a61aab-a108-4dbf-ad08-cc687de36a47",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4492,6 +4826,7 @@
         "imageId": "811a0bcb-9082-42b0-aec9-a7a43c8f7f3e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4505,6 +4840,7 @@
         "imageId": "f0e0cbfc-5f69-41fe-87b6-973a8efd460f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4518,6 +4854,7 @@
         "imageId": "9b64b8be-a7a7-47f3-b2f9-f56580a6f33a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4531,6 +4868,7 @@
         "imageId": "848ea5cf-f39f-43da-81af-99072234cd6e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4544,6 +4882,7 @@
         "imageId": "e38b4f75-bb80-449b-8d26-ad3b5f0e7d4f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4557,6 +4896,7 @@
         "imageId": "bf219f9a-e2a4-477d-9090-355491ada9a1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4570,6 +4910,7 @@
         "imageId": "a517b75f-4d29-4278-bd4d-54455587771d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4583,6 +4924,7 @@
         "imageId": "4d46c07f-66fb-4224-ad4c-0ca0d1175ee0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4596,6 +4938,7 @@
         "imageId": "5e29e042-c2a8-45ab-8eb8-962512b4b760",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4609,6 +4952,7 @@
         "imageId": "2457cc26-64da-4cd0-b7ca-bb59bd459271",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4622,6 +4966,7 @@
         "imageId": "970ec79c-2018-47c3-b304-2b5d4bd0d297",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4635,6 +4980,7 @@
         "imageId": "1cac7588-acdf-4c32-bf8e-6bd40ee8b2db",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4648,6 +4994,7 @@
         "imageId": "015aae2e-e07d-491d-b630-5a702156ddea",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4661,6 +5008,7 @@
         "imageId": "16977855-0b6e-4db5-a30e-bc43d3619bad",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4674,6 +5022,7 @@
         "imageId": "3f9a5496-d9b9-450d-b946-61d1097c8d9b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4687,6 +5036,7 @@
         "imageId": "b71e03e5-60e5-430b-870d-8faa04d49b4e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4700,6 +5050,7 @@
         "imageId": "8ed2ee57-0448-4a4d-a040-731d04214e04",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4713,6 +5064,7 @@
         "imageId": "995ad7b3-1630-4509-b1e9-4e2ddb2ae7db",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4726,6 +5078,7 @@
         "imageId": "d8660877-0382-49e5-aff4-eeb5eb0d65e5",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4739,6 +5092,7 @@
         "imageId": "cff9dff6-010c-4bd6-8d44-3ac360005439",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4752,6 +5106,7 @@
         "imageId": "2b0af9a6-b387-42ad-9adf-6e1b696feede",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4765,6 +5120,7 @@
         "imageId": "ad5084f7-e6f3-41fb-8c3b-8741d36ddaba",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4778,6 +5134,7 @@
         "imageId": "d896e257-c938-4068-804e-f0191f25c913",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4791,6 +5148,7 @@
         "imageId": "58df0812-5707-498a-9ad6-755d7f8b08fb",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4804,6 +5162,7 @@
         "imageId": "eef51641-592a-49d7-87f5-3c61e81fc87e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4817,6 +5176,7 @@
         "imageId": "c2b8d7d8-2712-4ca4-bff8-23917a4ef4ff",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4830,6 +5190,7 @@
         "imageId": "d1f855be-9d88-4f6e-835e-90bc2d7e5b65",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4843,6 +5204,7 @@
         "imageId": "7bde8c3c-ba06-409c-8c7c-b9cdf024a8ea",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4856,6 +5218,7 @@
         "imageId": "d94e9ff4-d024-47b6-bd99-6153d43ac879",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4869,6 +5232,7 @@
         "imageId": "de2ef41e-a6ee-4ce2-ab9d-727a68d2e176",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4882,6 +5246,7 @@
         "imageId": "b46dd495-2063-41b8-982c-37ecd05f0fbe",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4895,6 +5260,7 @@
         "imageId": "743ba032-abd4-4d1f-b827-d3891b5d424c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4908,6 +5274,7 @@
         "imageId": "a69dd314-f74a-4c49-b9d4-e36a1ad9a3b0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4921,6 +5288,7 @@
         "imageId": "102725af-52ae-43d2-9cea-9994e842eb58",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4934,6 +5302,7 @@
         "imageId": "3758cc00-67f7-4ecd-8f1f-d48d2e04faa0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4947,6 +5316,7 @@
         "imageId": "44966c0e-8fb7-4e0a-b492-84c101f5f211",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4960,6 +5330,7 @@
         "imageId": "dd21cceb-c5d5-47cb-bd7d-9a31bedd844a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4973,6 +5344,7 @@
         "imageId": "67c614ae-44c2-41b5-a545-2018be452c3f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4986,6 +5358,7 @@
         "imageId": "67a4396f-b3f3-4d89-9e73-74439fab841e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -4999,6 +5372,7 @@
         "imageId": "867db0f2-36f9-40f8-a13f-e3881e2ef88d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5012,6 +5386,7 @@
         "imageId": "c8d11be0-b63f-4775-9093-e68f5cc5e628",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5025,6 +5400,7 @@
         "imageId": "66c0d7d7-86f3-485b-8fde-40ed879135e9",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5038,6 +5414,7 @@
         "imageId": "63e3d72b-c983-4641-b858-2b7875308597",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5051,6 +5428,7 @@
         "imageId": "82cf014e-090b-4ab8-80e6-9bcd55204e19",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5064,6 +5442,7 @@
         "imageId": "fee4869f-6a1b-4547-8dbd-e81fb2b4876b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5077,6 +5456,7 @@
         "imageId": "608e741f-a74c-47bc-b822-327acd8e24bc",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5090,6 +5470,7 @@
         "imageId": "9c280255-214d-4992-b31a-8dd1b50f2298",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5103,6 +5484,7 @@
         "imageId": "e0492600-dd6e-4242-861d-f377682ed4b1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5116,6 +5498,7 @@
         "imageId": "6769066f-7eea-433f-b56b-5582c770f47c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5129,6 +5512,7 @@
         "imageId": "d8002648-134e-48ca-bf7e-721223a18749",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5142,6 +5526,7 @@
         "imageId": "b4394985-c509-4118-8f5a-0d8ce819afb2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5155,6 +5540,7 @@
         "imageId": "2af1b616-b972-4c0a-ad47-0e10f919593a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5168,6 +5554,7 @@
         "imageId": "cb13dbf1-5ded-4e44-a023-155f9782c596",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5181,6 +5568,7 @@
         "imageId": "c82b2ff0-7494-406f-af06-470ce8accd6f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5194,6 +5582,7 @@
         "imageId": "2657e2b7-5ef6-44d8-89d2-6e4545d3f74a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5207,6 +5596,7 @@
         "imageId": "78a93ee1-0cfb-4ebf-b9e3-bd0c895b0c72",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5220,6 +5610,7 @@
         "imageId": "96b5b311-11d1-4300-a999-897efe7fa42e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5233,6 +5624,7 @@
         "imageId": "a830426d-9327-4229-b8a5-7a4c0c08b529",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5246,6 +5638,7 @@
         "imageId": "92b751a2-da13-422c-a1c5-1f825d3ceab8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5259,6 +5652,7 @@
         "imageId": "9cf394d9-6365-4070-8d81-e732cd2981e1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5272,6 +5666,7 @@
         "imageId": "c7ca7bf9-3f48-4eaf-8755-4167b51e0e9c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5285,6 +5680,7 @@
         "imageId": "b4df9e58-dc01-45be-9b67-c5bd0ce64bb9",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5298,6 +5694,7 @@
         "imageId": "56702901-03f7-4e91-9c18-0878ce645849",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5311,6 +5708,7 @@
         "imageId": "08d70fa0-d165-4653-96c4-c3885a0c4949",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5324,6 +5722,7 @@
         "imageId": "691d2a4d-229e-49ed-baf5-06b6d9d97642",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5337,6 +5736,7 @@
         "imageId": "f43e84ff-85d2-4a36-8090-f7618c51ada8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5350,6 +5750,7 @@
         "imageId": "4161a599-4f42-4b08-8ad3-823cbd67c08b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5363,6 +5764,7 @@
         "imageId": "737c700f-6251-4dd5-9315-c7d6f8f4863f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5376,6 +5778,7 @@
         "imageId": "a85ff050-4874-49fb-b24e-f73719898389",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5389,6 +5792,7 @@
         "imageId": "3d1fa66d-0b4c-4b67-b427-aa46519159cd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5402,6 +5806,7 @@
         "imageId": "4ff0935c-9e34-4c6a-a50a-5a07163c247a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5415,6 +5820,7 @@
         "imageId": "0cb8d3ed-59f1-4fa2-ad1b-6921bbbedfda",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5428,6 +5834,7 @@
         "imageId": "90c8f8d6-e535-4695-8f8c-0934ee3288b6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5441,6 +5848,7 @@
         "imageId": "4dc0a2d0-3294-406d-ab0a-2100a08d2abf",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5454,6 +5862,7 @@
         "imageId": "56b42313-2614-4e71-bb7e-f21de1fa93ae",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5467,6 +5876,7 @@
         "imageId": "d54ae63d-c4e2-457c-b679-10ee672408b4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5480,6 +5890,7 @@
         "imageId": "4d9b34dc-7701-4fae-9158-bbd21d4a4735",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5493,6 +5904,7 @@
         "imageId": "0f704abe-3d10-47d2-8dd8-84d6a19a00ac",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5506,6 +5918,7 @@
         "imageId": "204eebdb-1242-4303-8d94-565a27c62380",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5519,6 +5932,7 @@
         "imageId": "e2d566f2-334c-407d-9319-c213dc40507d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5532,6 +5946,7 @@
         "imageId": "54a98efd-fbf7-4185-ac81-1c2604512253",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5545,6 +5960,7 @@
         "imageId": "32a80f60-3b59-4d1e-a975-65aed2fca91c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5558,6 +5974,7 @@
         "imageId": "f13d46ce-e52a-4f24-ac08-9e14a55f7f1e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5571,6 +5988,7 @@
         "imageId": "b34399a0-8edf-4b54-9490-cf1e38b78ce0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5584,6 +6002,7 @@
         "imageId": "ae93804a-d0d7-4fd6-8d8f-b0b0ae8fe187",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5597,6 +6016,7 @@
         "imageId": "3252612d-94ca-49f3-9176-32e13e100004",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5610,6 +6030,7 @@
         "imageId": "32e71686-3009-4130-8f73-721b8f63a77f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5623,6 +6044,7 @@
         "imageId": "c2722e11-e3bb-47da-a0ed-c9b479daa37c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5636,6 +6058,7 @@
         "imageId": "a86dc7d8-1d97-40ff-9dd5-e1ad0b0b2cab",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5649,6 +6072,7 @@
         "imageId": "011644ca-3a41-413c-8b70-4527b2a8a561",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5662,6 +6086,7 @@
         "imageId": "4792ba7f-442d-4ef6-912b-6aeadb9ce5a8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5675,6 +6100,7 @@
         "imageId": "47e5db4e-4c7e-4e7c-9935-a5ac593f83c8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5688,6 +6114,7 @@
         "imageId": "aaa8c110-9455-4634-85dd-868ff45976e2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5701,6 +6128,7 @@
         "imageId": "e198e22b-16a4-4c39-9996-016bfdfe3d3d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5714,6 +6142,7 @@
         "imageId": "0202e5e9-6262-48fa-958b-830006f49b02",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5727,6 +6156,7 @@
         "imageId": "04b38a65-0096-4865-a0be-5ed0e126a4f6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5740,6 +6170,7 @@
         "imageId": "7522622a-9e78-430b-8f7c-7726ee993c95",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5753,6 +6184,7 @@
         "imageId": "c08dea3a-c9b2-4d01-b9c4-70c2eb12f9f9",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5766,6 +6198,7 @@
         "imageId": "3eeb29e8-d2b7-4701-9262-0620b98afc0b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5779,6 +6212,7 @@
         "imageId": "3b245c79-b082-4da0-8195-e0194d608752",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5792,6 +6226,7 @@
         "imageId": "d6db6e14-c9a4-4b7f-9917-fc5b6da46c97",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5805,6 +6240,7 @@
         "imageId": "1c8c3fd4-e9ea-4393-87ac-f74bb85c8eee",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5818,6 +6254,7 @@
         "imageId": "1f346bbc-92dc-4a80-ae43-acc869d7cac0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5831,6 +6268,7 @@
         "imageId": "0e0fbdf9-ba6e-4ce9-a7e6-8d7640b1fa1a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5844,6 +6282,7 @@
         "imageId": "5c29968e-4382-4c57-871a-6f9eab753870",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5857,6 +6296,7 @@
         "imageId": "05cb59ae-d98e-44f2-924a-4ba063e0f9ea",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5870,6 +6310,7 @@
         "imageId": "99391c15-4187-461e-a259-0b2add5af146",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5883,6 +6324,7 @@
         "imageId": "879e3012-8381-4bf0-9b81-1bf383e0da18",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5896,6 +6338,7 @@
         "imageId": "aaac9af5-3f5f-4cf1-8451-34d0d0432319",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5909,6 +6352,7 @@
         "imageId": "7f3e12f4-bd11-42e3-91cb-36bb465990e2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5922,6 +6366,7 @@
         "imageId": "7d48e3e6-2cc3-41e4-b8f9-ea19743aaefb",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5935,6 +6380,7 @@
         "imageId": "569b02c5-db79-419a-84ce-f9acee27c2b9",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5948,6 +6394,7 @@
         "imageId": "98fad5d4-45b6-438a-8e43-e1652770e1dc",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5961,6 +6408,7 @@
         "imageId": "eb1a48c3-9e29-4661-9717-5a3a98bd78dd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5974,6 +6422,7 @@
         "imageId": "de2c0f69-f5a4-443e-8e88-23202fd8a59b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -5987,6 +6436,7 @@
         "imageId": "08279210-dfb5-45ed-b973-4fd4185789c6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6000,6 +6450,7 @@
         "imageId": "328543ce-c654-458f-a17c-78465e496b64",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6013,6 +6464,7 @@
         "imageId": "76a08115-a8e5-40b9-9acd-6ff7b97cf44e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6026,6 +6478,7 @@
         "imageId": "3fc70fae-f31b-4336-96fe-6f78c4041d18",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6039,6 +6492,7 @@
         "imageId": "2992cc28-c959-4396-bfdf-aaf99ee62a04",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6052,6 +6506,7 @@
         "imageId": "ff9d48cb-a5e7-4423-a399-56c942fdfdae",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6065,6 +6520,7 @@
         "imageId": "db15be10-c194-4fcd-8536-f7c505686a10",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6078,6 +6534,7 @@
         "imageId": "c030a6aa-3cba-40bd-bde2-3a3d5906014e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6091,6 +6548,7 @@
         "imageId": "edbd8b06-eed3-402b-b8db-8d8004a4db6b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6104,6 +6562,7 @@
         "imageId": "66a65ff7-2c0f-49bf-9d8f-f73f6dbf692f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6117,6 +6576,7 @@
         "imageId": "51e5cfc6-733d-42a9-9022-98c290289d3d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6130,6 +6590,7 @@
         "imageId": "a9c85956-8baa-455a-9516-7e3a1cbb9417",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6143,6 +6604,7 @@
         "imageId": "cf2cc4c9-98cd-4e08-9dba-e78549d41561",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6156,6 +6618,7 @@
         "imageId": "93de0f3b-2188-4ced-8305-aad4a55ecb0f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6169,6 +6632,7 @@
         "imageId": "1cf08c38-77e2-4c96-b804-73062bf73f3c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6182,6 +6646,7 @@
         "imageId": "579b4adf-beae-4046-9d9a-552e73a68e20",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6195,6 +6660,7 @@
         "imageId": "81cb1d4e-9d83-4cc8-bdee-ca65b93b97d2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6208,6 +6674,7 @@
         "imageId": "7c1f74d3-d47b-4701-b6d8-c90d11789328",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6221,6 +6688,7 @@
         "imageId": "a4dc22a9-4e55-46a9-9a2c-3dd4d898410b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6234,6 +6702,7 @@
         "imageId": "91d5bd84-55bb-4712-be2f-64119d5dae0b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6247,6 +6716,7 @@
         "imageId": "cd099a65-ea65-41e6-99fc-d95209bab8be",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6260,6 +6730,7 @@
         "imageId": "d589d8f0-c193-41f0-bef0-82b91db3364d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6273,6 +6744,7 @@
         "imageId": "5d8c4680-89c5-4c08-96a4-e6763cfd5b0e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6286,6 +6758,7 @@
         "imageId": "9f634da9-4c58-440e-b244-8ecb4412e42a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6299,6 +6772,7 @@
         "imageId": "cc78c02b-db8f-483d-b4c0-f2ed8ae1ba2c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6312,6 +6786,7 @@
         "imageId": "d5651129-3f01-4857-8217-8bb3f04b60ad",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6325,6 +6800,7 @@
         "imageId": "c6bb421e-6b3d-4f91-8e69-b666b40635af",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6338,6 +6814,7 @@
         "imageId": "baeaa117-3e5b-4f4d-8432-f78a1265159d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6351,6 +6828,7 @@
         "imageId": "9d98be29-fd22-4707-9c68-75b43b57a7b6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6364,6 +6842,7 @@
         "imageId": "4c0b52fd-ab3f-410e-ae8b-eba12d0ba3bc",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6377,6 +6856,7 @@
         "imageId": "de1f2839-2763-4e5a-94a1-cbf9c93a1ff5",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6390,6 +6870,7 @@
         "imageId": "3ba610b1-8e41-44fe-9532-d8f3bacc660f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6403,6 +6884,7 @@
         "imageId": "11b1d618-6cb6-43f8-8974-008b1358361f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6416,6 +6898,7 @@
         "imageId": "51501f11-0fcc-4bf9-926a-58c16755fa50",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6429,6 +6912,7 @@
         "imageId": "76e47704-a954-4159-bb0a-caede7621e71",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6442,6 +6926,7 @@
         "imageId": "0381d715-6222-4aa9-9bd5-bef67a9b1524",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6455,6 +6940,7 @@
         "imageId": "d86c9cdc-6064-44a8-b23b-94d2cb4edf09",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6468,6 +6954,7 @@
         "imageId": "0e3170bf-e9d9-4547-8d08-aa89c47561e7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6481,6 +6968,7 @@
         "imageId": "e2f7b961-e06b-4a29-b582-c43013419266",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6494,6 +6982,7 @@
         "imageId": "523f6eff-9b08-4492-8f3c-7eb62e6595db",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6507,6 +6996,7 @@
         "imageId": "4d66564b-401d-4a80-8161-ec62cb611c92",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6520,6 +7010,7 @@
         "imageId": "16e4ed2b-666e-41cb-8617-74a2a493247b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6533,6 +7024,7 @@
         "imageId": "6e895919-fee7-4be1-a425-b539a7186d96",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6546,6 +7038,7 @@
         "imageId": "1a15c889-61d2-49b6-b511-a61ec2a67da2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6559,6 +7052,7 @@
         "imageId": "d87451fd-e1b9-4410-bb75-17f1bca9e554",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6572,6 +7066,7 @@
         "imageId": "31ded18f-4f95-48f3-bb0c-de3cde6c0c10",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6585,6 +7080,7 @@
         "imageId": "dee26b05-e11b-4c4a-82be-1a8bbe7b8d56",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6598,6 +7094,7 @@
         "imageId": "7b5d0d02-b572-46b2-871d-7c174f78d1ec",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6611,6 +7108,7 @@
         "imageId": "3441e890-82be-4e22-bf1a-8d31c330638a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6624,6 +7122,7 @@
         "imageId": "02546078-f1ff-4d33-b460-2206010a03a3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6637,6 +7136,7 @@
         "imageId": "f96ed1c5-a206-4783-91c6-97d840af2a6b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6650,6 +7150,7 @@
         "imageId": "a397fb93-12e6-448f-9116-661bf464fa24",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6663,6 +7164,7 @@
         "imageId": "46024b8f-b58c-4ad9-8a52-7a5b1e83478c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6676,6 +7178,7 @@
         "imageId": "c2eac978-4e9c-4c9a-8d4a-b43249ff3ec8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6689,6 +7192,7 @@
         "imageId": "908bd906-0af1-40ac-bc57-77de5040bcb4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6702,6 +7206,7 @@
         "imageId": "7965a8f3-f95a-4dfb-8080-01c5d1910b1e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6715,6 +7220,7 @@
         "imageId": "6ad4b60e-7dd4-4cb1-8baa-b47a40446dae",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6728,6 +7234,7 @@
         "imageId": "5a8283e9-33bd-4a6a-91ac-af2b33c95231",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6741,6 +7248,7 @@
         "imageId": "aed12304-73d1-4c79-a496-f9b08263fd96",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6754,6 +7262,7 @@
         "imageId": "20bdac6f-45ac-4d0c-ac97-c03f8415894b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6767,6 +7276,7 @@
         "imageId": "83124025-5932-4f69-bf42-717f79e788e3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6780,6 +7290,7 @@
         "imageId": "3da6909a-eff5-43db-b104-49c75befc805",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6793,6 +7304,7 @@
         "imageId": "370b3228-b68b-4681-a274-630c24b859d7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6806,6 +7318,7 @@
         "imageId": "6f8cd7c1-88ef-43de-aad7-728914c8a0b8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6819,6 +7332,7 @@
         "imageId": "4e410416-7c48-43bd-b8c4-dc16abeb1e45",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6832,6 +7346,7 @@
         "imageId": "26b8bc4a-d9ec-4a5b-bcf8-68eedfe29f89",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6845,6 +7360,7 @@
         "imageId": "eb061b81-d348-4cb0-b189-7c05d8ae26cb",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6858,6 +7374,7 @@
         "imageId": "2e18bdb9-eafa-42c0-b556-d2869a2ecd81",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6871,6 +7388,7 @@
         "imageId": "4ab40640-c176-4816-aecf-b5d1cee265bd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6884,6 +7402,7 @@
         "imageId": "426eacbe-36c7-4e42-9ae0-8319568f0c27",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6897,6 +7416,7 @@
         "imageId": "4b713f19-ea3e-4554-af67-15093df4e16d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6910,6 +7430,7 @@
         "imageId": "8a96dfd5-0708-48a6-9e97-9a11cdfa6afa",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6923,6 +7444,7 @@
         "imageId": "26deb631-1a71-4852-8735-d004944ef956",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6936,6 +7458,7 @@
         "imageId": "209cd673-3e2b-4e77-bd42-c9f7ed96ec45",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6949,6 +7472,7 @@
         "imageId": "57e02197-df74-4069-b0b4-64ac6f67f637",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6962,6 +7486,7 @@
         "imageId": "fc92ebcd-2f57-4304-b612-90b71772485a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6975,6 +7500,7 @@
         "imageId": "829c92bf-d8f2-412a-a01b-7e95e8cb5d84",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -6988,6 +7514,7 @@
         "imageId": "18d23a20-7513-4f1f-80ca-5b38d474429e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7001,6 +7528,7 @@
         "imageId": "517f9bbc-dde2-4585-81ba-c98a54d70d2c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7014,6 +7542,7 @@
         "imageId": "5aa82855-66dd-4454-9a83-88f374ebc199",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7027,6 +7556,7 @@
         "imageId": "011225bd-5bb0-4e88-b13c-d1c31e5d8be2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7040,6 +7570,7 @@
         "imageId": "d3afd6d3-da9c-48f4-a481-1ac90e8a464c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7053,6 +7584,7 @@
         "imageId": "f180a975-79e7-499c-aa10-19ebb830349d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7066,6 +7598,7 @@
         "imageId": "e1ab9ed6-4ecf-43db-8553-b7c315b8d96c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7079,6 +7612,7 @@
         "imageId": "77e57a49-5d43-42f2-a243-002e3142cca0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7092,6 +7626,7 @@
         "imageId": "b350c60d-4b97-4dc5-b21d-2c4efc4706fc",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7105,6 +7640,7 @@
         "imageId": "e8e76919-22f8-44f5-9976-827561cf2867",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7118,6 +7654,7 @@
         "imageId": "3617cf5f-b2a0-4212-9016-abe186b36c26",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7131,6 +7668,7 @@
         "imageId": "9ea2058a-5952-43ba-9b76-28d76290eec4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7144,6 +7682,7 @@
         "imageId": "7b2560eb-43d9-406c-89b0-a08794f86c7a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7157,6 +7696,7 @@
         "imageId": "0f9ba1cc-70ff-4032-9cf9-cf391ffe99cc",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7170,6 +7710,7 @@
         "imageId": "43a68ae9-76f3-47c2-a444-de5743009baf",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7183,6 +7724,7 @@
         "imageId": "55ce2cd2-f641-41f6-bbde-1b590d880aad",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7196,6 +7738,7 @@
         "imageId": "e1b4de1b-4368-4a4f-a87a-e9a9e33025ea",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7209,6 +7752,7 @@
         "imageId": "5bfedf92-4d50-4d8f-8bb5-fb4aac487302",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7222,6 +7766,7 @@
         "imageId": "ab9a64a3-d0a1-410b-8794-e363f5506834",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7235,6 +7780,7 @@
         "imageId": "3ec38e81-9a14-488c-935d-80dfad93ec98",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7248,6 +7794,7 @@
         "imageId": "4daec27d-b0ba-429d-b463-1c0ba556a45a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7261,6 +7808,7 @@
         "imageId": "1af6e1b2-634a-4a9c-92df-fb60a3bf5243",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7274,6 +7822,7 @@
         "imageId": "fef4c441-d193-4b74-a2b0-b9193d3ecff6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7287,6 +7836,7 @@
         "imageId": "35703045-30c8-440d-be38-5ca6c153891e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7300,6 +7850,7 @@
         "imageId": "4cc12697-ad7d-44e6-bf6c-df93dd5e9197",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7313,6 +7864,7 @@
         "imageId": "ef26e269-cab3-4cf9-8d91-0ee1e194a422",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7326,6 +7878,7 @@
         "imageId": "7b0d37ef-4bcd-49b9-880d-b1cdd685b03f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7339,6 +7892,7 @@
         "imageId": "dc52963d-a803-40b4-afad-7fb2fdfd6253",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7352,6 +7906,7 @@
         "imageId": "5251b559-ec09-4b14-904e-dd30602ef342",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7365,6 +7920,7 @@
         "imageId": "ede428ee-d982-4086-b8a6-5c0670bc1854",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7378,6 +7934,7 @@
         "imageId": "3b21c8eb-1378-436c-9343-8944955f3e26",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7391,6 +7948,7 @@
         "imageId": "3572585a-1fa6-46f6-a01f-086cb0d24c8b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7404,6 +7962,7 @@
         "imageId": "45ae3f23-0f23-4b68-bdbb-03c4633bbcba",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7417,6 +7976,7 @@
         "imageId": "91147600-5a37-4ad2-b7d3-7aa8b475ce1f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7430,6 +7990,7 @@
         "imageId": "853c1c1e-0b11-40f7-9057-e59a536f0527",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7443,6 +8004,7 @@
         "imageId": "0e774eed-a012-43aa-a71b-43243cac8d4a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7456,6 +8018,7 @@
         "imageId": "806de723-3330-4987-a2b2-b96193af3bac",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7469,6 +8032,7 @@
         "imageId": "ed41f46c-9dd6-4c10-87f2-33a0754542b3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7482,6 +8046,7 @@
         "imageId": "795b52f1-b9a4-416a-b709-c0a417a68f23",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7495,6 +8060,7 @@
         "imageId": "3b393f6e-aa41-4da4-8cf1-6fd04de2011b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7508,6 +8074,7 @@
         "imageId": "2971f275-b3b9-488f-a118-4a8d22fac398",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7521,6 +8088,7 @@
         "imageId": "1184f304-3f01-42bb-abbd-302b3a7410b7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7534,6 +8102,7 @@
         "imageId": "4db0907c-b1dc-4033-9ea9-9435612ecac9",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7547,6 +8116,7 @@
         "imageId": "152dc340-6a5a-4013-96ea-29f2c695ab4c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7560,6 +8130,7 @@
         "imageId": "79f0f7d8-3fc1-414b-9514-d7513caace0e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7573,6 +8144,7 @@
         "imageId": "48dd5645-3c6b-42f4-8be4-d6cf9d95fcaa",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7586,6 +8158,7 @@
         "imageId": "5f746352-cf01-4412-9029-4b47339d8c7f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7599,6 +8172,7 @@
         "imageId": "18b243f5-7ec2-4222-9101-5026c15e276b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7612,6 +8186,7 @@
         "imageId": "b9f7a199-a100-4d17-898b-73f4ca212941",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7625,6 +8200,7 @@
         "imageId": "3f25af12-b7f4-4b07-b416-155942619d0f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7638,6 +8214,7 @@
         "imageId": "7a1591aa-76a0-493d-9c24-eb204f72a760",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7651,6 +8228,7 @@
         "imageId": "6458a36a-a46b-4747-8093-99e3a41a62eb",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7664,6 +8242,7 @@
         "imageId": "ccb52291-7456-46e6-bf91-9ebd006d4645",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7677,6 +8256,7 @@
         "imageId": "5a7934b7-3723-4515-85e4-09884a855fa3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7690,6 +8270,7 @@
         "imageId": "89c8e4ef-6bd7-44b6-889a-047a53ff9acd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7703,6 +8284,7 @@
         "imageId": "53b288d0-0952-49a6-9a69-4a63b93475f7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7716,6 +8298,7 @@
         "imageId": "9354f704-cc14-4a60-83da-91f99ebf14e7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7729,6 +8312,7 @@
         "imageId": "746581c0-6f07-4685-8b57-b8773c52b197",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7742,6 +8326,7 @@
         "imageId": "50a69a8b-6482-4945-8cc8-f8314e56d934",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7755,6 +8340,7 @@
         "imageId": "8a50c6e5-039c-422d-89be-7e62683e567c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7768,6 +8354,7 @@
         "imageId": "4b95874c-cf49-4f4e-9f28-efd2b8dd38d3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7781,6 +8368,7 @@
         "imageId": "2badb5d1-8c1d-4af5-82cc-2590204d95f6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7794,6 +8382,7 @@
         "imageId": "484d4f74-ceaf-4470-89b9-a870c9600547",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7807,6 +8396,7 @@
         "imageId": "31fb6d66-0795-448c-a08a-86eb2acf826a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7820,6 +8410,7 @@
         "imageId": "4bbb42c2-cba3-4888-b883-ae45df90d5c4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7833,6 +8424,7 @@
         "imageId": "c3e45269-6f50-4e7a-9950-9a8a21eb2dcb",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7846,6 +8438,7 @@
         "imageId": "bf6bdbbb-1c76-4d8a-a2e1-adb69a1cd41b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7859,6 +8452,7 @@
         "imageId": "2e0a4b44-6792-40c3-8374-cb666fea8462",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7872,6 +8466,7 @@
         "imageId": "dad0f718-fe07-4c0d-a548-c0b9859bf457",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7885,6 +8480,7 @@
         "imageId": "2d84da67-819d-46fa-a0b5-161a9afdd5f7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7898,6 +8494,7 @@
         "imageId": "f3187ace-491f-473d-8d2e-239c202bf72f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7911,6 +8508,7 @@
         "imageId": "0906a6e9-872d-4eb6-9bdf-c723a4f7e2fb",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7924,6 +8522,7 @@
         "imageId": "14a6b5d8-983f-4bd8-8ce9-d3e26fc8d19c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7937,6 +8536,7 @@
         "imageId": "4944cd01-6c4c-4413-94b1-f22291543522",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7950,6 +8550,7 @@
         "imageId": "b6cd1be6-9aba-4cd6-b244-36cd03f4a14d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7963,6 +8564,7 @@
         "imageId": "f17c2b13-6824-4a9a-ba4e-e276e2604fb0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7976,6 +8578,7 @@
         "imageId": "a451fc0e-d9ff-4859-9aef-d888bbe681d4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -7989,6 +8592,7 @@
         "imageId": "9c0cec4b-6388-44d0-be0d-e9a1c7df37b1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8002,6 +8606,7 @@
         "imageId": "5cb4e541-50a6-4c29-b5f9-0187715878f8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8015,6 +8620,7 @@
         "imageId": "731227fe-adda-45d3-b2f6-c86aad5a17f7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8028,6 +8634,7 @@
         "imageId": "0f8d902d-bedf-4710-b046-8b6646843bc5",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8041,6 +8648,7 @@
         "imageId": "286247b6-805f-4097-a387-65be758f48b6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8054,6 +8662,7 @@
         "imageId": "f93a83b3-954c-49d9-99de-4c4864e67b0e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8067,6 +8676,7 @@
         "imageId": "fb2a2e2f-1bc1-4a87-bd28-16ed1a7eea00",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8080,6 +8690,7 @@
         "imageId": "2e5cf427-c586-4ba4-a04d-b0761095923a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8093,6 +8704,7 @@
         "imageId": "32013f08-938c-4843-b922-7bcc73a6432f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8106,6 +8718,7 @@
         "imageId": "5d42ff8c-358c-44a7-8c41-7d57f2b3afa7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8119,6 +8732,7 @@
         "imageId": "fd1773df-2c70-4e93-abe9-1f82a36ebd7c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8132,6 +8746,7 @@
         "imageId": "2f101eea-636a-4a78-ac4d-be87f530c670",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8145,6 +8760,7 @@
         "imageId": "a3c3e073-0131-47b4-8678-5f71642e063e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8158,6 +8774,7 @@
         "imageId": "8b6ab1dd-f3b6-49c9-af57-2b280861c7aa",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8171,6 +8788,7 @@
         "imageId": "22c3c8c2-b617-465d-8088-a22a69ea41b9",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8184,6 +8802,7 @@
         "imageId": "d115c2e6-15b7-45aa-b164-94f53a2e5020",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8197,6 +8816,7 @@
         "imageId": "8cf143fe-4e46-4e13-ac38-7d7e06fa6bfc",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8210,6 +8830,7 @@
         "imageId": "8e262748-0189-4271-bea1-49023b223b9c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8223,6 +8844,7 @@
         "imageId": "96b729c7-3dd7-4f15-999f-1ca8866f7721",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8236,6 +8858,7 @@
         "imageId": "1a23306f-b9f4-42f7-a431-a9c8dd1239e0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8249,6 +8872,7 @@
         "imageId": "28b4533e-f5ee-4bac-95d6-458445a0534d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8262,6 +8886,7 @@
         "imageId": "223830a9-e3e4-4a7d-bbb6-b0eb9b4e5422",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8275,6 +8900,7 @@
         "imageId": "22548d83-32ca-460f-aa53-0ab262fa35eb",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8288,6 +8914,7 @@
         "imageId": "5a8663b9-548a-43db-8c78-76da96cb454f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8301,6 +8928,7 @@
         "imageId": "8b44df4d-60cd-445a-b6f8-651026df6e23",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8314,6 +8942,7 @@
         "imageId": "3973aa80-5217-4df9-9f93-a5b81cad54e5",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8327,6 +8956,7 @@
         "imageId": "ca470011-e423-4d55-9630-ecb184bd9dc2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8340,6 +8970,7 @@
         "imageId": "8cd4c2f7-1053-439b-8903-c5ebeac871ce",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8353,6 +8984,7 @@
         "imageId": "6684691f-4630-452f-ab72-513c19905c5d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8366,6 +8998,7 @@
         "imageId": "38a3f83c-5421-4e8e-8657-02a1730d6fb9",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8379,6 +9012,7 @@
         "imageId": "3921031f-523f-4d60-90b1-0a6ed6a1a3ca",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8392,6 +9026,7 @@
         "imageId": "12208245-1b8a-497e-b8d2-0533414df3b1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8405,6 +9040,7 @@
         "imageId": "e6bd8750-9d51-4ac5-ba76-174bb039a957",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8418,6 +9054,7 @@
         "imageId": "b7cd2cb7-95fc-47a4-8ac7-d3f662640e6a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8431,6 +9068,7 @@
         "imageId": "2f0bf272-a089-46bb-8d6a-f4193a266dc4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8444,6 +9082,7 @@
         "imageId": "57cced16-e3c7-4b1d-be1a-868e0108215e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8457,6 +9096,7 @@
         "imageId": "34a2223a-d31a-4c47-a109-2e1378772416",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8470,6 +9110,7 @@
         "imageId": "eb477d2e-1764-4d04-9c3b-8da01eb32d05",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8483,6 +9124,7 @@
         "imageId": "62b3da6a-c594-41f0-b225-3cd91d2a769e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8496,6 +9138,7 @@
         "imageId": "b15db428-97b1-4ffa-9c0d-b487eabb3996",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8509,6 +9152,7 @@
         "imageId": "7678e86a-4051-4f87-a440-c992831ee4c7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8522,6 +9166,7 @@
         "imageId": "49f56796-949b-47c5-990a-b752fdd8132e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8535,6 +9180,7 @@
         "imageId": "44bb81cf-9faf-442b-94e0-46db45e5eb40",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8548,6 +9194,7 @@
         "imageId": "0ee73da2-9251-4e2d-a41f-98a643661ac2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8561,6 +9208,7 @@
         "imageId": "d98c5a9c-617e-4085-bdba-ce87783443e4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8574,6 +9222,7 @@
         "imageId": "12543d55-0e19-490a-98de-11f6889f6699",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8587,6 +9236,7 @@
         "imageId": "ba867270-7ce8-429e-87a3-a26ba0be4c49",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8600,6 +9250,7 @@
         "imageId": "fd2dd283-aa3f-4458-a65a-09d948a1b19a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8613,6 +9264,7 @@
         "imageId": "14333228-0cfc-4675-9b69-444eb34b91db",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8626,6 +9278,7 @@
         "imageId": "5c12f0d5-9826-4200-9c74-71e45bec46c5",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8639,6 +9292,7 @@
         "imageId": "3159b9f9-096d-4bd7-adbe-3238c88febd4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8652,6 +9306,7 @@
         "imageId": "b769c275-c6be-4960-bf89-0e7996baae99",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8665,6 +9320,7 @@
         "imageId": "52e844a7-327d-4c19-acb4-b3f68f1f36e2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8678,6 +9334,7 @@
         "imageId": "16594039-399c-4c6c-adce-6353df8b5e34",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8691,6 +9348,7 @@
         "imageId": "5ccfb143-1179-4117-a903-887b35644f4c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8704,6 +9362,7 @@
         "imageId": "25165898-37b7-481f-bb9c-bd711d958daa",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8717,6 +9376,7 @@
         "imageId": "61285ba0-ed61-4889-8b40-d131364cdab0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8730,6 +9390,7 @@
         "imageId": "fb324415-d045-4ee7-b7e5-53cd2a9e8d5f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8743,6 +9404,7 @@
         "imageId": "1c06bb5a-94c3-4e08-8dcd-ed66e4c523b4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8756,6 +9418,7 @@
         "imageId": "6da03d4d-791b-46ef-96b3-a7c58e296f89",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8769,6 +9432,7 @@
         "imageId": "8a7d96d5-6958-4f3f-a561-d1bc3b5ff969",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8782,6 +9446,7 @@
         "imageId": "07770024-2e2c-43d7-90e2-28dfed65c52e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8795,6 +9460,7 @@
         "imageId": "63d288a1-c44e-44ef-a76f-b8bacc6a170e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8808,6 +9474,7 @@
         "imageId": "d316264e-912a-456f-b020-f4bacead467b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8821,6 +9488,7 @@
         "imageId": "039338c7-e73f-4d49-be32-1e9739db94da",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8834,6 +9502,7 @@
         "imageId": "50dec352-8f98-4b1e-a00c-b85f09cae065",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8847,6 +9516,7 @@
         "imageId": "4ae45fe2-39e2-4991-97f8-77b01ebcda7d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8860,6 +9530,7 @@
         "imageId": "df3a3f34-3461-4b04-bf7d-16f1567c98ec",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8873,6 +9544,7 @@
         "imageId": "46cdde5b-3084-4a67-b35f-836fee76ed2e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8886,6 +9558,7 @@
         "imageId": "a6f85bd5-4db4-4cd1-a252-2370aed9f470",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8899,6 +9572,7 @@
         "imageId": "d1cc959e-9f83-4af8-bc64-debf90382341",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8912,6 +9586,7 @@
         "imageId": "a39f6cc2-dfba-46c4-adb0-c51be7303bf4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8925,6 +9600,7 @@
         "imageId": "f9a9f595-d5ff-4c38-b57c-e9dd55b8b021",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8938,6 +9614,7 @@
         "imageId": "649f6eef-f10d-4f71-9468-a20eb1b6e537",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8951,6 +9628,7 @@
         "imageId": "c8db08cc-dd4d-423d-8860-520671f31d25",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8964,6 +9642,7 @@
         "imageId": "6d776bde-f660-496e-ab26-3ac1687b9b18",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8977,6 +9656,7 @@
         "imageId": "a22e9455-c23e-4b67-a1cc-cb3109e208f3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -8990,6 +9670,7 @@
         "imageId": "3b387d2c-81d8-4d7c-ac91-6d821f0118a0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9003,6 +9684,7 @@
         "imageId": "3962ae39-be70-4fe1-966d-e2b63be825ce",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9016,6 +9698,7 @@
         "imageId": "dec9cbfa-6bdc-4b1a-9a4a-dbe01abdd15d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9029,6 +9712,7 @@
         "imageId": "52618eba-66ea-401d-8343-ffc3f259c719",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9042,6 +9726,7 @@
         "imageId": "495ca599-0373-4fca-ab13-1ca3ad186d9d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9055,6 +9740,7 @@
         "imageId": "6a9bcf0e-115b-42e8-a7f9-fe43c93e50dd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9068,6 +9754,7 @@
         "imageId": "71430fca-0299-4207-9116-a76d1f3c1c5e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9081,6 +9768,7 @@
         "imageId": "4f3b1674-027f-4df1-9ecc-8d072f05367c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9094,6 +9782,7 @@
         "imageId": "6609dbb4-8d73-4c58-b0be-5b869c80cccb",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9107,6 +9796,7 @@
         "imageId": "edcd8172-8d32-44f4-bb0f-eff65d464dee",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9120,6 +9810,7 @@
         "imageId": "f36316dd-5ae8-429e-9016-04c8d7d162a1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9133,6 +9824,7 @@
         "imageId": "4bebce3b-70df-4f66-ad42-cf79af972ff7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9146,6 +9838,7 @@
         "imageId": "8e9d1981-8e74-40e7-8f2b-2b72210bcc46",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9159,6 +9852,7 @@
         "imageId": "a201fac3-3603-406e-8361-375cf6a1751b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9172,6 +9866,7 @@
         "imageId": "30e3301a-3ea0-4f19-8a6f-db9ac2b6220d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9185,6 +9880,7 @@
         "imageId": "f1804729-0847-4743-812c-d172f9497083",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9198,6 +9894,7 @@
         "imageId": "2cabf420-cd93-4abc-ae5b-5e302597a97b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9211,6 +9908,7 @@
         "imageId": "1d455b8e-78c8-4b74-a6fb-a937778bdae5",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9224,6 +9922,7 @@
         "imageId": "78c22af2-a9aa-4c9f-a274-313d2d9e6fe0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9237,6 +9936,7 @@
         "imageId": "71324525-87c8-4fe3-b89c-4a03cdc0e439",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9250,6 +9950,7 @@
         "imageId": "8e579950-5807-43f4-b160-78a36d01b365",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9263,6 +9964,7 @@
         "imageId": "363b4f6c-4b27-4250-94e0-d37dff8d0249",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9276,6 +9978,7 @@
         "imageId": "1c7e6535-b00a-46b7-a104-2bdb862d448d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9289,6 +9992,7 @@
         "imageId": "77de2e3e-1e87-41b4-a47a-64eb56f82619",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9302,6 +10006,7 @@
         "imageId": "ad4473d5-1bf9-4636-b4a9-ce1d50f64467",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9315,6 +10020,7 @@
         "imageId": "103dc3e6-8f0b-48f5-9700-6b71c89fd15f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9328,6 +10034,7 @@
         "imageId": "2e194e58-e733-46c4-9dc7-b687c5cacc1a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9341,6 +10048,7 @@
         "imageId": "97e2fa88-f102-4410-95a4-8c2abaafaed2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9354,6 +10062,7 @@
         "imageId": "04ca1c34-747d-43dc-ae85-0baf94088532",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9367,6 +10076,7 @@
         "imageId": "752739c8-cbd1-43b9-b396-652e47626777",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9380,6 +10090,7 @@
         "imageId": "513fbb18-0c5d-48c7-801c-c306bad671cc",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9393,6 +10104,7 @@
         "imageId": "55b44d0e-2e4d-4b26-9579-72ef8345b15b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9406,6 +10118,7 @@
         "imageId": "bd42d77b-8386-4366-85d7-2d61b764da5b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9419,6 +10132,7 @@
         "imageId": "5e162332-c24b-432f-80ca-10b2f55096f6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9432,6 +10146,7 @@
         "imageId": "bc63782d-3c2f-425c-8964-558f00787f2f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9445,6 +10160,7 @@
         "imageId": "82694590-48ba-4ad0-86e4-077255840dc3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9458,6 +10174,7 @@
         "imageId": "98546d78-5020-418e-bcb0-435c8a17e4a1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9471,6 +10188,7 @@
         "imageId": "febc6eab-b87c-45d0-8055-a7dd5a051438",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9484,6 +10202,7 @@
         "imageId": "92de2a0d-67f3-471d-8cd4-f3182b834676",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9497,6 +10216,7 @@
         "imageId": "e0d8617f-a8b1-4fdc-8e89-d833a8ae0ded",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9510,6 +10230,7 @@
         "imageId": "d8efd6bd-2c6b-4500-bcd5-521fb94e5011",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9523,6 +10244,7 @@
         "imageId": "e0a1887e-47e4-430d-8b7f-7aa1d16a46e8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9536,6 +10258,7 @@
         "imageId": "2e024c7a-6cb7-4a74-853a-b4f11684e34e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9549,6 +10272,7 @@
         "imageId": "99c5b56f-ec57-422e-a598-dc23f8249386",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9562,6 +10286,7 @@
         "imageId": "b07c8b7d-8e20-4b9d-9267-6db60e581359",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9575,6 +10300,7 @@
         "imageId": "b0841205-bb06-41a2-8700-ae6bb00f4dd9",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9588,6 +10314,7 @@
         "imageId": "4dae57d7-f81d-4f4c-8e56-b8f020a083e2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9601,6 +10328,7 @@
         "imageId": "0e8a6009-b773-43ba-b250-cf3c69a30921",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9614,6 +10342,7 @@
         "imageId": "6c08accd-7a75-4c64-ac01-f815bbc19754",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9627,6 +10356,7 @@
         "imageId": "f97bd558-02a6-4590-a26f-f8be61847480",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9640,6 +10370,7 @@
         "imageId": "421f9b0b-91af-43bd-a8a1-30670cf28003",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9653,6 +10384,7 @@
         "imageId": "4914f337-b343-4005-9e5c-073fcec87e23",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9666,6 +10398,7 @@
         "imageId": "f0850ea7-7411-41a3-8b0c-660deaf32d02",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9679,6 +10412,7 @@
         "imageId": "2039eb9d-85ee-4e88-9b33-b78033ca564e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9692,6 +10426,7 @@
         "imageId": "b0b9a02c-538c-456e-b9ee-a4caef8b1caa",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9705,6 +10440,7 @@
         "imageId": "5f942999-1562-4f11-a4da-4ac01f4a874d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9718,6 +10454,7 @@
         "imageId": "5ed00d50-6159-4b5a-b38e-8df084ddab4f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9731,6 +10468,7 @@
         "imageId": "d8bcab1a-60c6-4de9-9e3d-7134e69a6577",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9744,6 +10482,7 @@
         "imageId": "23ece9a8-0146-4756-bcc2-d73c2b9b8c19",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9757,6 +10496,7 @@
         "imageId": "06548532-d55e-43f6-93de-4af4826965ca",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9770,6 +10510,7 @@
         "imageId": "04f37b81-20f4-446c-812e-bf599800da3b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9783,6 +10524,7 @@
         "imageId": "bd5a8e1f-5058-47c1-9f0d-7269f4026bd4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9796,6 +10538,7 @@
         "imageId": "2fd784b7-0c58-4d22-b3c7-14ae16fde38e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9809,6 +10552,7 @@
         "imageId": "a3a83e41-f99a-4929-bb91-461f9492c658",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9822,6 +10566,7 @@
         "imageId": "696d819f-7262-49df-bb53-2c73667c85b3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9835,6 +10580,7 @@
         "imageId": "e45f6bc8-cc32-4cdc-8638-3181e80181cf",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9848,6 +10594,7 @@
         "imageId": "c9efdfd5-a174-4ac4-97f3-a4d859004347",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9861,6 +10608,7 @@
         "imageId": "c253ec35-c897-4b84-b6d0-7bcf4004912e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9874,6 +10622,7 @@
         "imageId": "bb08779a-ccd3-43d3-b498-7f390a901eb0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9887,6 +10636,7 @@
         "imageId": "6ed32728-c028-4a53-8cfe-83124830b6ac",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9900,6 +10650,7 @@
         "imageId": "d6cbfbf8-3c50-4cf4-a2fc-f392a92dccdd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9913,6 +10664,7 @@
         "imageId": "2daf3ac4-d910-4c4c-94c9-5c92eaeedf95",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9926,6 +10678,7 @@
         "imageId": "739f26f1-0040-4fe5-92b6-869e55f044ad",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9939,6 +10692,7 @@
         "imageId": "9fde1efb-2ecb-40ce-83a1-f4fb33a79b42",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9952,6 +10706,7 @@
         "imageId": "8c6ee28f-7cf9-42e5-89f3-a1ee9edffb02",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9965,6 +10720,7 @@
         "imageId": "bf5dd12a-8bc5-4699-8f45-846b3fe21c76",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9978,6 +10734,7 @@
         "imageId": "3e522b84-0ab9-470c-a37e-8740c1702c5b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -9991,6 +10748,7 @@
         "imageId": "421324a7-4d6c-4a0a-bff4-4cd417be2db0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10004,6 +10762,7 @@
         "imageId": "0a9afb99-9cff-40e3-864c-39249201c3ce",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10017,6 +10776,7 @@
         "imageId": "5f913768-6bf3-4edb-8017-e4928c86a751",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10030,6 +10790,7 @@
         "imageId": "a0b417a3-1ed6-4420-81a5-a2d8a8c73f87",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10043,6 +10804,7 @@
         "imageId": "91aaf385-321e-4bb1-9b74-b7abb45c8519",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10056,6 +10818,7 @@
         "imageId": "9c756587-7a99-449f-bb1e-0d92db909f0b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10069,6 +10832,7 @@
         "imageId": "86e12dc5-07df-4ac5-afdd-717450022841",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10082,6 +10846,7 @@
         "imageId": "39556d8c-6c9d-4c90-948b-dca11d718393",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10095,6 +10860,7 @@
         "imageId": "108443ed-3e84-4b8b-ad1a-44ecde1af8fd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10108,6 +10874,7 @@
         "imageId": "6027b93f-2d91-428d-a84f-048d46880f2e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10121,6 +10888,7 @@
         "imageId": "92f396b1-1373-4b86-9374-f8bf802b4a8a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10134,6 +10902,7 @@
         "imageId": "934095b2-fbce-4321-abcc-14dd0eb0e872",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10147,6 +10916,7 @@
         "imageId": "fa47d870-8962-45b4-9318-decae7ee6e57",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10160,6 +10930,7 @@
         "imageId": "e4472479-5010-4c52-9356-79e4b9c92b45",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10173,6 +10944,7 @@
         "imageId": "b4a77efa-3ae9-46f2-b8b5-9490dcd81fee",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10186,6 +10958,7 @@
         "imageId": "857a4108-7686-4fc3-9822-1d654f3f7211",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10199,6 +10972,7 @@
         "imageId": "3aa2f46f-a0d4-43ab-ad5e-0511c7729de8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10212,6 +10986,7 @@
         "imageId": "9c0305d9-597a-4cb8-a94a-194869f67760",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10225,6 +11000,7 @@
         "imageId": "1b099031-224f-49be-b5e7-504316d2cadd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10238,6 +11014,7 @@
         "imageId": "f782976c-edb8-4ac7-ae9c-0593c9bb2369",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10251,6 +11028,7 @@
         "imageId": "8add3326-f021-4238-9423-979e7efbd1a0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10264,6 +11042,7 @@
         "imageId": "3a034eaf-6fc6-49a7-b694-5e7ed0179f9b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10277,6 +11056,7 @@
         "imageId": "82ee2d4a-ca84-460c-8706-97cabcb8e4b3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10290,6 +11070,7 @@
         "imageId": "91fd88ed-790b-4e36-b0be-e54b89d0e32a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10303,6 +11084,7 @@
         "imageId": "96b51f40-abdf-480f-888f-a047aa4f1797",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10316,6 +11098,7 @@
         "imageId": "7535089e-f99e-4f4b-8f17-636c22af5e79",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10329,6 +11112,7 @@
         "imageId": "bd38e6c4-02e7-4fd7-8071-e8d6f2b109c2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10342,6 +11126,7 @@
         "imageId": "1c87ce59-3dca-4bf0-8c4b-adc8be5e5073",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10355,6 +11140,7 @@
         "imageId": "13d74a71-11ef-4f54-9c5d-59d7f658f256",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10368,6 +11154,7 @@
         "imageId": "58226e60-3836-4b74-b184-0a26074e2046",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10381,6 +11168,7 @@
         "imageId": "18723d83-c3ec-47db-830d-431157a5848e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10394,6 +11182,7 @@
         "imageId": "a7e98aea-4e20-4f7a-a457-6e52bdf1ff17",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10407,6 +11196,7 @@
         "imageId": "b927d82b-64a9-46f1-b028-f13b9e63c828",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10420,6 +11210,7 @@
         "imageId": "fd23aaaa-4672-4588-b4d5-e9c53da0fb15",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10433,6 +11224,7 @@
         "imageId": "0d822e31-37a8-4042-9793-b8e6898ace0c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10446,6 +11238,7 @@
         "imageId": "8945be50-fc14-4bc0-a70b-fe7b19ed47cd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10459,6 +11252,7 @@
         "imageId": "7624cad1-bd93-4e4c-b828-3064b793ba49",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10472,6 +11266,7 @@
         "imageId": "7dd98911-c226-404c-ad8e-07cf94cb4a3d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10485,6 +11280,7 @@
         "imageId": "0a626bb4-776a-40ac-95b6-43f881547c17",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10498,6 +11294,7 @@
         "imageId": "f68f9b7e-d264-4d11-ac87-21608816ec7e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10511,6 +11308,7 @@
         "imageId": "ea779854-655a-44a4-b280-ed95a9e72922",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10524,6 +11322,7 @@
         "imageId": "e4d67343-b564-4966-94f1-70381db630f8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10537,6 +11336,7 @@
         "imageId": "479f787d-3f5a-478c-98d0-829c485281fd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10550,6 +11350,7 @@
         "imageId": "54f8b911-ab5a-4f5b-8a29-c8cb4f865936",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10563,6 +11364,7 @@
         "imageId": "04cb7cf0-e5e6-4fc5-892e-c5784d4d3c3b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10576,6 +11378,7 @@
         "imageId": "a9da9a25-1816-4e31-bd9a-8691ccde1e5b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10589,6 +11392,7 @@
         "imageId": "c243a405-0811-4631-9507-2fcfe1ae523c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10602,6 +11406,7 @@
         "imageId": "719a8c25-dc58-4f33-9696-2cf1279bd7c1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10615,6 +11420,7 @@
         "imageId": "64936b4f-54e9-4bb0-82cc-75798b5d2aaf",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10628,6 +11434,7 @@
         "imageId": "2896e4cb-c977-4bb5-b63a-776d4e60accb",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10641,6 +11448,7 @@
         "imageId": "1d83c854-6987-4ba5-8770-f3003d536508",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10654,6 +11462,7 @@
         "imageId": "ca4dd943-4602-4be0-91f5-ea5748a710c6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10667,6 +11476,7 @@
         "imageId": "69e8f66a-386e-4888-b8ff-1615a2116d2d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10680,6 +11490,7 @@
         "imageId": "841263f6-8abb-4d48-96f4-fe6d9ba7ee53",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10693,6 +11504,7 @@
         "imageId": "7c97a457-3942-4184-a579-b3ae88225fa8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10706,6 +11518,7 @@
         "imageId": "f207d53a-2493-4b39-b79f-384c91aad917",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10719,6 +11532,7 @@
         "imageId": "cb208dea-620b-4264-9556-decb43eacc3e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10732,6 +11546,7 @@
         "imageId": "f6b2fd78-7387-46c2-b0ee-632b8d34f95c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10745,6 +11560,7 @@
         "imageId": "07aa1cc0-6fea-453c-827d-9ef0faa296bb",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10758,6 +11574,7 @@
         "imageId": "dfb497f1-01df-4500-8312-3566c1e24cf0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10771,6 +11588,7 @@
         "imageId": "233d6fe2-779f-4753-963a-5323ca3e0e7f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10784,6 +11602,7 @@
         "imageId": "436e2438-fd2d-439e-89b8-7bdd01ab3e6f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10797,6 +11616,7 @@
         "imageId": "a8834500-50ff-4c2d-a66f-8a9b1bdaa6bf",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10810,6 +11630,7 @@
         "imageId": "140d5044-1461-4bde-b59c-0f767e156338",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10823,6 +11644,7 @@
         "imageId": "27602789-3ef4-4ccf-bc2e-c79d08315369",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10836,6 +11658,7 @@
         "imageId": "87c1ebb5-555b-4b95-a2b4-668781aaa7ca",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10849,6 +11672,7 @@
         "imageId": "fba59293-3e47-40bf-9fa5-dda46458aadc",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10862,6 +11686,7 @@
         "imageId": "aa809476-cbad-47e4-badc-475c786f88fd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10875,6 +11700,7 @@
         "imageId": "164efb57-da7a-4660-82fb-df3dd361e2a6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10888,6 +11714,7 @@
         "imageId": "11cc6dd8-b545-4125-aaf1-eb31e3956b8c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10901,6 +11728,7 @@
         "imageId": "f9fd9d49-71fb-4b6a-bf50-667b870285c3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10914,6 +11742,7 @@
         "imageId": "4e2a9b98-5e9a-45c8-bed0-1a690ae5ad85",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10927,6 +11756,7 @@
         "imageId": "15f40658-54e5-4ef3-b4e0-c249d1ae0bbd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10940,6 +11770,7 @@
         "imageId": "18ccdd57-027f-41db-be7f-f4ea9838883b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10953,6 +11784,7 @@
         "imageId": "39a822fb-a960-4c8b-990e-1dc52750d3db",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10966,6 +11798,7 @@
         "imageId": "0142e7c7-87d1-4b91-8556-e45513a19c48",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10979,6 +11812,7 @@
         "imageId": "1c9dd38b-ff24-4dfa-9c35-43b56647c54a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -10992,6 +11826,7 @@
         "imageId": "4d8d1569-2c71-4cf8-8e1f-ed65731f3596",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11005,6 +11840,7 @@
         "imageId": "435926c6-513e-4836-9f89-7f2ece69207a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11018,6 +11854,7 @@
         "imageId": "0ad00b57-5fc6-4f86-81d6-626e659e0abc",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11031,6 +11868,7 @@
         "imageId": "d71a63fe-2ade-42a6-a8be-4d3400bf6ec4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11044,6 +11882,7 @@
         "imageId": "a7301349-5a72-4d05-816b-7cd49d5e140e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11057,6 +11896,7 @@
         "imageId": "068484d4-4bef-43d2-a1f6-089d4d7528b3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11070,6 +11910,7 @@
         "imageId": "6ebd01f0-89ce-4bae-a4f5-fb60792e1d21",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11083,6 +11924,7 @@
         "imageId": "0e89f7c1-b5b3-44e5-9721-d3cd5a4b647b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11096,6 +11938,7 @@
         "imageId": "ca328fdf-796b-470c-942c-5c9a6c1b30ec",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11109,6 +11952,7 @@
         "imageId": "c95fd787-2e79-4212-83d9-06788925ec31",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11122,6 +11966,7 @@
         "imageId": "26632f3a-9f77-4d2e-98ba-bae7a03de369",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11135,6 +11980,7 @@
         "imageId": "6cf3309b-34d8-4dcc-9b09-e85e50548877",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11148,6 +11994,7 @@
         "imageId": "34864ce0-8a1c-4d63-aefe-7a73f01611f1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11161,6 +12008,7 @@
         "imageId": "d74d437c-8e5d-488d-aecd-c4cba1416476",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11174,6 +12022,7 @@
         "imageId": "7205ff17-5e7a-4648-94a8-bf3cbf1e2561",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11187,6 +12036,7 @@
         "imageId": "01bb9fd2-2361-491d-92b2-3766460e82de",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11200,6 +12050,7 @@
         "imageId": "3619955f-af88-40ac-8bcd-941a2a27502b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11213,6 +12064,7 @@
         "imageId": "9955c776-7f53-4268-8f84-b327088a5170",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11226,6 +12078,7 @@
         "imageId": "0231daae-714f-45b5-8a25-d260116c3529",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11239,6 +12092,7 @@
         "imageId": "b11e5181-5244-4ea1-9caf-4e10e6aa1eb3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11252,6 +12106,7 @@
         "imageId": "22314556-c404-467d-8363-37ff1abec0d6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11265,6 +12120,7 @@
         "imageId": "111d1388-bd71-4412-a65d-74f9d2756a51",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11278,6 +12134,7 @@
         "imageId": "db1adf20-dc3d-482d-92bf-c01229511e0c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11291,6 +12148,7 @@
         "imageId": "fd5fee84-8fff-4f0d-9480-77757c91f24e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11304,6 +12162,7 @@
         "imageId": "46bbb347-cd36-430c-b7c3-722b9a051fc2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11317,6 +12176,7 @@
         "imageId": "0a2be060-ad85-4a59-aa6f-f06ce6052bad",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11330,6 +12190,7 @@
         "imageId": "f8eee4df-409d-4351-8e15-6a3ce9f440b7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11343,6 +12204,7 @@
         "imageId": "bf2b021e-d0bb-45b9-833c-2c8bb5a91d49",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11356,6 +12218,7 @@
         "imageId": "48133efe-aa9e-47fb-85a5-1cc7f54455d6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11369,6 +12232,7 @@
         "imageId": "32a4bc54-67b6-49bd-8320-36f44f573fc4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11382,6 +12246,7 @@
         "imageId": "8c973e5a-b536-474a-af38-a7d387947edd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11395,6 +12260,7 @@
         "imageId": "44f45540-6d01-4b9b-8588-d68c95498408",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11408,6 +12274,7 @@
         "imageId": "6c3af262-4676-43d0-a7c2-c1a3980e2bfa",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11421,6 +12288,7 @@
         "imageId": "d44d691f-f38f-4816-9df7-b8d16b137bd0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11434,6 +12302,7 @@
         "imageId": "6da3a000-b62f-4708-aaea-0cb9ed003f2f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11447,6 +12316,7 @@
         "imageId": "e976ba49-333b-4687-a523-f5859b0fa05a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11460,6 +12330,7 @@
         "imageId": "d9d94d85-9613-4674-9a0d-3c4d50be8905",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11473,6 +12344,7 @@
         "imageId": "61b9caa8-b98c-4afe-92c8-b70477288df0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11486,6 +12358,7 @@
         "imageId": "65014004-87d3-4d02-a270-327b3c888303",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11499,6 +12372,7 @@
         "imageId": "b16525a5-71cc-44da-8b3a-7129bc17ce9f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11512,6 +12386,7 @@
         "imageId": "ee1187a8-b67a-408a-83a8-fb55f538c1f4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11525,6 +12400,7 @@
         "imageId": "772665fa-1769-4c2f-a4a5-818888ecf9e0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11538,6 +12414,7 @@
         "imageId": "cb1f35e7-18cd-4dfe-a048-a741044421b6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11551,6 +12428,7 @@
         "imageId": "3ea02c10-85b2-4661-9b07-b93794ba0695",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11564,6 +12442,7 @@
         "imageId": "0d6cc7f9-125e-4326-b88e-9f81caf8eb0e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11577,6 +12456,7 @@
         "imageId": "3509d597-ea88-40da-8b58-eccd1dda76da",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11590,6 +12470,7 @@
         "imageId": "d01e070b-de76-48d7-a7ce-d00aaa92c560",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11603,6 +12484,7 @@
         "imageId": "326ba5a2-a222-44ed-986d-7faf86ee0d57",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11616,6 +12498,7 @@
         "imageId": "65391879-c2c4-4b2a-8876-5089a7b29f5a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11629,6 +12512,7 @@
         "imageId": "8edc32f6-6563-46f4-8904-78399bda7fe4",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11642,6 +12526,7 @@
         "imageId": "b795418e-794a-4dc0-a513-c5f9b11ec6e6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11655,6 +12540,7 @@
         "imageId": "7e5e6047-cd35-4676-bbc5-4f1013974c46",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11668,6 +12554,7 @@
         "imageId": "77e5f823-a7a6-4a1a-927c-f66be10ce24c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11681,6 +12568,7 @@
         "imageId": "39e1f3b5-0990-4697-ae6b-e9fcece0288b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11694,6 +12582,7 @@
         "imageId": "9c4872a3-ac6f-483e-a4e1-ac1e1accd625",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11707,6 +12596,7 @@
         "imageId": "98c7c68d-623a-42b3-b472-6fc5aaf267a6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11720,6 +12610,7 @@
         "imageId": "9d58e939-e4fd-4725-9481-1b3eb88a5444",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11733,6 +12624,7 @@
         "imageId": "15da7858-1693-460f-9f05-5e8e4cf8ec70",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11746,6 +12638,7 @@
         "imageId": "13ab4c4f-6a09-4432-9d6b-5fbc524f637b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11759,6 +12652,7 @@
         "imageId": "0d37bd0a-6e7b-448a-8714-466bcb241f86",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11772,6 +12666,7 @@
         "imageId": "f9d27977-8ed8-456c-b63a-42a93ab620f3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11785,6 +12680,7 @@
         "imageId": "388766af-795d-4310-91df-9eaece4899c6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11798,6 +12694,7 @@
         "imageId": "23418907-abd9-4772-817a-e083860538e8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11811,6 +12708,7 @@
         "imageId": "559b77a3-0de3-40c7-b67d-a1019aa2b0e2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11824,6 +12722,7 @@
         "imageId": "d0d844c3-3120-47d6-ad50-9d6f2eb686ae",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11837,6 +12736,7 @@
         "imageId": "69807924-4917-4247-b901-50689aa6a5cf",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11850,6 +12750,7 @@
         "imageId": "d688b618-8b7d-43f2-8e8f-cae7bf216e3c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11863,6 +12764,7 @@
         "imageId": "389e22d9-94b1-4152-932c-a790351968c2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11876,6 +12778,7 @@
         "imageId": "bec18023-7e2a-49b6-be2d-93c7e0ffe166",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11889,6 +12792,7 @@
         "imageId": "72de2288-7d13-410d-ad0b-31bd8fa1d9d2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11902,6 +12806,7 @@
         "imageId": "d90cdeaf-0f7d-42ef-9d95-3ba1410ab2f2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11915,6 +12820,7 @@
         "imageId": "cf2e4b1d-13fa-4029-aae9-81e934f1c0d1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11928,6 +12834,7 @@
         "imageId": "12ba0b5e-a22c-496e-b4c3-e9dbcac17d61",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11941,6 +12848,7 @@
         "imageId": "5b145259-34a5-4ec4-bcfe-d1a8142a84e2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11954,6 +12862,7 @@
         "imageId": "7c3fc0af-3925-4c89-86d8-37582d63c4bb",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11967,6 +12876,7 @@
         "imageId": "be9a1d22-5da9-458b-b5d3-d4b6e8977c01",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11980,6 +12890,7 @@
         "imageId": "7b2398b7-2b23-4395-ab68-d8a0368d31b0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -11993,6 +12904,7 @@
         "imageId": "c091edfd-858f-4560-96b0-52e5cb6c9d57",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12006,6 +12918,7 @@
         "imageId": "45d702b1-56f6-411f-9f18-71c6fee19a6b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12019,6 +12932,7 @@
         "imageId": "c19ca9be-bdd4-4f0e-bf4d-32721afeff84",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12032,6 +12946,7 @@
         "imageId": "0b6e2b24-b884-4600-9423-5b91bdf50803",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12045,6 +12960,7 @@
         "imageId": "f233f20a-10cd-4512-a5fd-021e998efbdd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12058,6 +12974,7 @@
         "imageId": "be207c30-72bb-44b8-abf7-4bb7940e1211",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12071,6 +12988,7 @@
         "imageId": "2fc1886b-c2c6-4dca-91d0-281cc9f197e8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12084,6 +13002,7 @@
         "imageId": "6ef6a0c1-3bc0-4b73-90f3-bd7d0229728e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12097,6 +13016,7 @@
         "imageId": "1ef79552-dd5a-42f0-ae19-04c1c7ae2f1f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12110,6 +13030,7 @@
         "imageId": "2ea24af8-04b4-481e-a0d5-0a3b483296f8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12123,6 +13044,7 @@
         "imageId": "5b7a34b9-53f7-4232-b6b0-2ef194c25aec",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12136,6 +13058,7 @@
         "imageId": "49b91335-c3ec-484c-bb25-a36bdcac1f9d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12149,6 +13072,7 @@
         "imageId": "2dadb31b-b5b1-4ba8-a025-c3567aaee2aa",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12162,6 +13086,7 @@
         "imageId": "50c034c6-6d3f-4569-927b-e08170bd1dde",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12175,6 +13100,7 @@
         "imageId": "85c7d30b-9efc-4f86-8b88-4ec8b3832d12",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12188,6 +13114,7 @@
         "imageId": "aa16850a-62b4-4dec-bb3b-a172437d789c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12201,6 +13128,7 @@
         "imageId": "b99afbb4-e646-436b-b73f-4b4ca0d0a27c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12214,6 +13142,7 @@
         "imageId": "bc8ead84-0768-44bb-9792-07a6e72f3536",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12227,6 +13156,7 @@
         "imageId": "4d830276-6ede-4ea4-919e-2cf8017428fd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12240,6 +13170,7 @@
         "imageId": "75c36f51-d63c-4ce7-b011-7b964d1805e3",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12253,6 +13184,7 @@
         "imageId": "693fa1d1-ca97-4f15-aa01-b574fcbc11c6",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12266,6 +13198,7 @@
         "imageId": "8847a8bb-dcef-469d-9ab5-11c16ec536c9",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12279,6 +13212,7 @@
         "imageId": "8fa2a3a5-63ed-4f41-962f-08575f0dda73",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12292,6 +13226,7 @@
         "imageId": "a0426c71-ef4a-44c0-9cd4-e7086a0d0946",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12305,6 +13240,7 @@
         "imageId": "802e41df-6f60-483f-8f7d-ec88efe05103",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12318,6 +13254,7 @@
         "imageId": "8d3e91c0-9632-4f22-b72f-151fe79dc8cd",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12331,6 +13268,7 @@
         "imageId": "ff7ddb40-f07e-4f8d-9daa-44c6dc9f9502",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12344,6 +13282,7 @@
         "imageId": "4b18d186-00d5-443a-bac8-da01e494ad7d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12357,6 +13296,7 @@
         "imageId": "6b9375cd-59bd-48b4-b7ac-02cb2c29d1ab",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12370,6 +13310,7 @@
         "imageId": "a00f8bb6-9138-403b-8361-5b003dac0c1a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12383,6 +13324,7 @@
         "imageId": "2884e046-bf85-4f23-8973-6ef961972a4f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12396,6 +13338,7 @@
         "imageId": "da581c53-134b-4fbb-a7fb-9f99c346c16b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12409,6 +13352,7 @@
         "imageId": "8e11e159-5fc6-4047-97db-3f943f67446f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12422,6 +13366,7 @@
         "imageId": "ca349958-8ea1-4b84-ac6c-04f35699af2a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12435,6 +13380,7 @@
         "imageId": "2d2ac7d1-9a90-4150-8388-f2ddfe944e86",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12448,6 +13394,7 @@
         "imageId": "39a2bb7a-4ff9-4bb1-a912-a18399470b41",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12461,6 +13408,7 @@
         "imageId": "eff349f2-ad09-4ff4-b45b-af42a30c7fe0",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12474,6 +13422,7 @@
         "imageId": "95c82ad1-8763-48cd-b57b-a2caba889718",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12487,6 +13436,7 @@
         "imageId": "138f1294-0a13-44a3-bf7c-d03095e7362a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12500,6 +13450,7 @@
         "imageId": "fff8414b-ac0a-4e44-b9c2-79eceba9504b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12513,6 +13464,7 @@
         "imageId": "a51c0b0a-a27f-44b4-9061-61b805d78e20",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12526,6 +13478,7 @@
         "imageId": "97f2e233-9a38-4955-be99-63c0b5feb329",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12539,6 +13492,7 @@
         "imageId": "6fcda971-3343-4a39-8f2d-80b5a96888e7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12552,6 +13506,7 @@
         "imageId": "7eca934a-fa74-4320-9cb3-cafa02b96751",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12565,6 +13520,7 @@
         "imageId": "e8ee8886-87be-4fe1-8d76-384641888831",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12578,6 +13534,7 @@
         "imageId": "45fc46ef-2023-4e5f-bf31-68ebb62fe31a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12591,6 +13548,7 @@
         "imageId": "43687d63-a323-4e07-9b2f-5209b36e829c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12604,6 +13562,7 @@
         "imageId": "121a71ec-3533-417d-9fb0-18c5b64a2736",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12617,6 +13576,7 @@
         "imageId": "ac2e24fb-4426-4b3b-90df-a25b7a32f350",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12630,6 +13590,7 @@
         "imageId": "98cf4ea1-3cfe-47d1-af40-9f914a69518b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12643,6 +13604,7 @@
         "imageId": "859d1251-12c9-42d8-8109-a955fb5c9a91",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12656,6 +13618,7 @@
         "imageId": "f378c246-9b4a-472a-8736-474496346f58",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12669,6 +13632,7 @@
         "imageId": "057b0eaf-7015-4c16-a9f2-c2d68091b72a",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12682,6 +13646,7 @@
         "imageId": "148d427d-57da-475f-a1f7-eb184d08e652",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12695,6 +13660,7 @@
         "imageId": "9be17b2f-7fd0-4a11-b7d4-e4782d787686",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12708,6 +13674,7 @@
         "imageId": "0e6109c2-06f9-465f-b3e6-585740c80120",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12721,6 +13688,7 @@
         "imageId": "38e0a363-e068-428d-b245-dcb16b5ac5a1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12734,6 +13702,7 @@
         "imageId": "f6710ac9-c4de-4430-811b-f6c55eabdfd7",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12747,6 +13716,7 @@
         "imageId": "36df49a3-1b7e-4f6f-91dd-186d761b2a62",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12760,6 +13730,7 @@
         "imageId": "107d27a1-bfb8-44f7-8154-58d5cebd8e91",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12773,6 +13744,7 @@
         "imageId": "fec9e77d-b2e3-4735-b9e4-22e03df9f223",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12786,6 +13758,7 @@
         "imageId": "03419218-d877-453f-8a74-52043978bdd2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12799,6 +13772,7 @@
         "imageId": "e367407f-d5cc-4b10-9b51-c53e90cdba64",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12812,6 +13786,7 @@
         "imageId": "9b3ac605-6812-40ca-b5aa-665a99b70eba",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12825,6 +13800,7 @@
         "imageId": "72e981af-ed1c-41ea-b74b-82a7ac05723f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12838,6 +13814,7 @@
         "imageId": "a47642d1-6cda-46e1-b022-3f8e4c0a10e8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12851,6 +13828,7 @@
         "imageId": "1405b346-0099-4fd5-82f0-ac9ffb48480d",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12864,6 +13842,7 @@
         "imageId": "dcf27411-f756-4bda-8349-515d33a33599",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12877,6 +13856,7 @@
         "imageId": "82ebe4eb-4f8e-4874-aaac-c28f0db2f4d1",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12890,6 +13870,7 @@
         "imageId": "e0c1a402-e653-41c7-aa37-e88830d2536b",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12903,6 +13884,7 @@
         "imageId": "bb45c49e-623d-4bf2-8895-4fcfce16f7ee",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12916,6 +13898,7 @@
         "imageId": "4551f9d0-9e1b-4df2-be91-8591110ad11e",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12929,6 +13912,7 @@
         "imageId": "5135648b-ff86-48d5-b628-c8ee72940dc8",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12942,6 +13926,7 @@
         "imageId": "9f1b31b8-3a3f-463a-af63-91f80c7ba8eb",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12955,6 +13940,7 @@
         "imageId": "e65aa1cf-72d6-4931-b929-e7b0b4e0dc45",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12968,6 +13954,7 @@
         "imageId": "758e0f72-0664-4c97-a374-64186ccc4067",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12981,6 +13968,7 @@
         "imageId": "86ee9e72-0f5b-4e9f-bc67-b0b00f30010c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -12994,6 +13982,7 @@
         "imageId": "5433a30f-bedf-438a-ac4b-d1e4656c31be",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -13007,6 +13996,7 @@
         "imageId": "fe4062e8-0c5f-4df5-ba25-4d2c3159ed7f",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -13020,6 +14010,7 @@
         "imageId": "cb454f72-bf18-4af7-b0a7-164babf49d71",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -13033,6 +14024,7 @@
         "imageId": "df58d4ef-93a8-4cae-bff5-1ba689c2fefb",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -13046,6 +14038,7 @@
         "imageId": "618c7796-76f7-4dbf-a5d3-2ce7056a91c2",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -13059,6 +14052,7 @@
         "imageId": "0bc36c2c-6b61-4668-8fec-bd2ed8a03047",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -13072,6 +14066,7 @@
         "imageId": "9566906d-34bd-46fa-a608-885aa612583c",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       },
       {
@@ -13085,6 +14080,7 @@
         "imageId": "f9b87ba8-6365-4725-963b-78c4e231a035",
         "imagePlanes": 1,
         "imageWidth": 28,
+        "imagePartition": 0,
         "annotations": []
       }
     ],

--- a/src/store/sagas/classifier/fitSaga.ts
+++ b/src/store/sagas/classifier/fitSaga.ts
@@ -14,6 +14,8 @@ import {
 } from "../../selectors";
 import { architectureOptionsSelector } from "../../selectors/architectureOptionsSelector";
 import { rescaleOptionsSelector } from "../../selectors/rescaleOptionsSelector";
+import { trainImagesSelector } from "../../selectors/trainImagesSelector";
+import { valImagesSelector } from "../../selectors/valImagesSelector";
 
 export function* fitSaga(action: any): any {
   //TODO: there are some redundancies between fitSaga and openSaga/preprocessSaga. Should we be calling openSaga
@@ -49,12 +51,15 @@ export function* fitSaga(action: any): any {
   let data = yield select(dataSelector);
 
   if (!data) {
-    const images = yield select(categorizedImagesSelector);
-
     const categories = yield select(createdCategoriesSelector);
 
+    const trainImages = yield select(trainImagesSelector);
+
+    const valImages = yield select(valImagesSelector);
+
     data = yield preprocess(
-      images,
+      trainImages,
+      valImages,
       categories,
       architectureOptions.inputShape,
       rescaleOptions,

--- a/src/store/sagas/classifier/predictSaga.ts
+++ b/src/store/sagas/classifier/predictSaga.ts
@@ -20,9 +20,11 @@ export function* predictSaga(action: any): any {
 
   const categories = yield select(createdCategoriesSelector);
 
-  const images = yield select(testImagesSelector);
+  const testImages = yield select(testImagesSelector);
 
-  const data = yield preprocess_predict(images, rescaleOptions);
+  if (!testImages.length) return;
+
+  const data = yield preprocess_predict(testImages, rescaleOptions);
 
   const { imageIds, categoryIds } = yield predictCategories(
     model,

--- a/src/store/sagas/classifier/predictSaga.ts
+++ b/src/store/sagas/classifier/predictSaga.ts
@@ -4,24 +4,28 @@ import { createdCategoriesSelector, openedSelector } from "../../selectors";
 import { rescaleOptionsSelector } from "../../selectors/rescaleOptionsSelector";
 import { preprocess_predict } from "../../coroutines/classifier/preprocess_predict";
 import { predictCategories } from "../../coroutines/classifier/predictCategories";
-import { uncategorizedImagesSelector } from "../../selectors/uncategorizedImagesSelector";
+import { testImagesSelector } from "../../selectors/testImagesSelector";
 import { fittedSelector } from "../../selectors/fittedSelector";
 
 export function* predictSaga(action: any): any {
   const rescaleOptions = yield select(rescaleOptionsSelector);
 
-  let fitted = yield select(fittedSelector);
+  let model = yield select(fittedSelector);
 
-  if (!fitted) return;
+  if (!model) {
+    model = yield select(openedSelector);
+  }
+
+  if (!model) return;
 
   const categories = yield select(createdCategoriesSelector);
 
-  const images = yield select(uncategorizedImagesSelector);
+  const images = yield select(testImagesSelector);
 
   const data = yield preprocess_predict(images, rescaleOptions);
 
   const { imageIds, categoryIds } = yield predictCategories(
-    fitted,
+    model,
     data,
     categories
   ); //returns an array of Image ID and an array of corresponding categories ID

--- a/src/store/sagas/classifier/preprocessSaga.ts
+++ b/src/store/sagas/classifier/preprocessSaga.ts
@@ -8,10 +8,13 @@ import {
 } from "../../selectors";
 import { architectureOptionsSelector } from "../../selectors/architectureOptionsSelector";
 import { rescaleOptionsSelector } from "../../selectors/rescaleOptionsSelector";
+import { trainImagesSelector } from "../../selectors/trainImagesSelector";
+import { valImagesSelector } from "../../selectors/valImagesSelector";
 
 export function* preprocessSaga(): any {
-  const images = yield select(categorizedImagesSelector);
+  const trainImages = yield select(trainImagesSelector);
 
+  const valImages = yield select(valImagesSelector);
   const categories = yield select(createdCategoriesSelector);
 
   const architectureOptions = yield select(architectureOptionsSelector);
@@ -21,7 +24,8 @@ export function* preprocessSaga(): any {
   const trainingPercentage = yield select(trainingPercentageSelector);
 
   const data = yield preprocess(
-    images,
+    trainImages,
+    valImages,
     categories,
     architectureOptions.inputShape,
     rescaleOptions,

--- a/src/store/selectors/categorizedImagesSelector.ts
+++ b/src/store/selectors/categorizedImagesSelector.ts
@@ -7,6 +7,6 @@ export const categorizedImagesSelector = ({
   project: Project;
 }): Array<Image> => {
   return project.images.filter((image: Image) => {
-    return image.categoryId !== "00000000-0000-0000-0000-000000000000";
+    return image.partition !== 2;
   });
 };

--- a/src/store/selectors/serializedProjectSelector.ts
+++ b/src/store/selectors/serializedProjectSelector.ts
@@ -23,6 +23,7 @@ export const serializedProjectSelector = ({
       imageId: image.id,
       imagePlanes: image.shape.planes,
       imageWidth: image.shape.width,
+      imagePartition: image.partition,
       annotations: [],
     };
   });

--- a/src/store/selectors/testImagesSelector.ts
+++ b/src/store/selectors/testImagesSelector.ts
@@ -1,12 +1,12 @@
 import { Project } from "../../types/Project";
 import { Image } from "../../types/Image";
 
-export const uncategorizedImagesSelector = ({
+export const testImagesSelector = ({
   project,
 }: {
   project: Project;
 }): Array<Image> => {
   return project.images.filter((image: Image) => {
-    return image.categoryId === "00000000-0000-0000-0000-000000000000";
+    return image.partition === 2;
   });
 };

--- a/src/store/selectors/trainImagesSelector.ts
+++ b/src/store/selectors/trainImagesSelector.ts
@@ -1,12 +1,12 @@
 import { Project } from "../../types/Project";
 import { Image } from "../../types/Image";
 
-export const categorizedImagesSelector = ({
+export const trainImagesSelector = ({
   project,
 }: {
   project: Project;
 }): Array<Image> => {
   return project.images.filter((image: Image) => {
-    return image.categoryId !== "00000000-0000-0000-0000-000000000000";
+    return image.partition === 0;
   });
 };

--- a/src/store/selectors/valImagesSelector.ts
+++ b/src/store/selectors/valImagesSelector.ts
@@ -1,12 +1,12 @@
 import { Project } from "../../types/Project";
 import { Image } from "../../types/Image";
 
-export const categorizedImagesSelector = ({
+export const valImagesSelector = ({
   project,
 }: {
   project: Project;
 }): Array<Image> => {
   return project.images.filter((image: Image) => {
-    return image.categoryId !== "00000000-0000-0000-0000-000000000000";
+    return image.partition === 1;
   });
 };

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -23,6 +23,7 @@ const dummyImage: Image = {
     planes: 1,
     frames: 1,
   },
+  partition: 2,
 };
 
 const initialState: Project = {
@@ -117,7 +118,7 @@ export const projectSlice = createSlice({
           id: serializedImage.imageId,
           instances: [], //TODO implement this once we have imported the Annotation Type from Annotator into Piximi classifier
           name: serializedImage.imageFilename,
-          partition: 0,
+          partition: serializedImage.imagePartition,
           shape: {
             width: serializedImage.imageWidth,
             height: serializedImage.imageHeight,
@@ -153,7 +154,7 @@ export const projectSlice = createSlice({
           id: serializedImage.imageId,
           instances: [], //TODO implement this once we have imported the Annotation Type from Annotator into Piximi classifier
           name: serializedImage.imageFilename,
-          partition: 0,
+          partition: serializedImage.imagePartition,
           shape: {
             width: serializedImage.imageWidth,
             height: serializedImage.imageHeight,
@@ -232,6 +233,12 @@ export const projectSlice = createSlice({
         });
         if (index >= 0) {
           state.images[index].categoryId = action.payload.categoryId;
+          if (
+            action.payload.categoryId === "00000000-0000-0000-0000-000000000000"
+          ) {
+            //If assigned category is unknown, then this image is moved to test set
+            state.images[index].partition = 2;
+          }
         }
       });
     },

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -255,6 +255,19 @@ export const projectSlice = createSlice({
         }
       });
     },
+    updateImagesPartition(
+      state: Project,
+      action: PayloadAction<{ ids: Array<string>; partition: number }>
+    ) {
+      action.payload.ids.forEach((imageId, idx) => {
+        const index = findIndex(state.images, (image: Image) => {
+          return image.id === imageId;
+        });
+        if (index >= 0) {
+          state.images[index].partition = action.payload.partition;
+        }
+      });
+    },
     updateTask(state: Project, action: PayloadAction<{ task: Task }>) {
       state.task = action.payload.task;
     },

--- a/src/types/Image.ts
+++ b/src/types/Image.ts
@@ -8,5 +8,5 @@ export type Image = {
   src: string;
   shape: Shape;
   instances: Array<Instance>;
-  partition?: number;
+  partition: number;
 };

--- a/src/types/SerializedImageType.ts
+++ b/src/types/SerializedImageType.ts
@@ -11,5 +11,6 @@ export type SerializedImageType = {
   imageId: string;
   imagePlanes: number;
   imageWidth: number;
+  imagePartition: number;
   annotations: Array<Instance>;
 };


### PR DESCRIPTION
* At every new fit, take all images that don't belong to the test data and randomly assign either a train or val partition. 
* All images that have partition `2` (test) images are those that are used for prediction after training. 

Closes #86  and Closes #87 .