### PR TITLE
Closes issue #90

### DIFF
--- a/src/components/ImageViewer/CategoriesList/CategoriesList/CategoriesList.tsx
+++ b/src/components/ImageViewer/CategoriesList/CategoriesList/CategoriesList.tsx
@@ -532,7 +532,6 @@ const CreateCategoryListItem = () => {
 const OpenListItem = () => {
   return (
     <>
-      {/*// @ts-ignore */}
       <PopupState variant="popover">
         {(popupState) => (
           <>
@@ -557,7 +556,6 @@ const SaveListItem = () => {
 
   return (
     <>
-      {/*// @ts-ignore */}
       <PopupState variant="popover">
         {(popupState) => (
           <>

--- a/src/components/ImageViewer/Content/Stage/Annotations/ConfirmedAnnotations/Annotation/Annotation.tsx
+++ b/src/components/ImageViewer/Content/Stage/Annotations/ConfirmedAnnotations/Annotation/Annotation.tsx
@@ -54,9 +54,7 @@ export const Annotation = ({ annotation }: AnnotationProps) => {
 
   return (
     <>
-      {/*// @ts-ignore */}
       <ReactKonva.Group>
-        {/*// @ts-ignore */}
         <ReactKonva.Image
           id={annotation.id}
           image={imageMask}

--- a/src/components/ImageViewer/Content/Stage/ColorAnnotationToolTip/ColorAnnotationToolTip.tsx
+++ b/src/components/ImageViewer/Content/Stage/ColorAnnotationToolTip/ColorAnnotationToolTip.tsx
@@ -41,9 +41,7 @@ export const ColorAnnotationToolTip = ({
 
   return (
     <>
-      {/*// @ts-ignore */}
       <ReactKonva.Group>
-        {/*// @ts-ignore */}
         <ReactKonva.Line
           points={[
             toolTipPosition.x,
@@ -55,7 +53,6 @@ export const ColorAnnotationToolTip = ({
           strokeWidth={1}
           stroke="white"
         />
-        {/*// @ts-ignore */}
         <ReactKonva.Label
           position={{
             x: toolTipPosition.x * stageScale,
@@ -63,9 +60,7 @@ export const ColorAnnotationToolTip = ({
           }}
           opacity={0.75}
         >
-          {/*// @ts-ignore */}
           <ReactKonva.Tag fill={"black"} />
-          {/*// @ts-ignore */}
           <ReactKonva.Text
             fill={"white"}
             fontSize={12}

--- a/src/components/ImageViewer/Content/Stage/Image/Image.tsx
+++ b/src/components/ImageViewer/Content/Stage/Image/Image.tsx
@@ -67,7 +67,6 @@ export const Image = React.forwardRef<Konva.Image>((_, ref) => {
   if (!src) {
     return (
       <>
-        {/*// @ts-ignore */}
         <ReactKonva.Text
           x={
             boundingClientRect.x +
@@ -86,7 +85,6 @@ export const Image = React.forwardRef<Konva.Image>((_, ref) => {
 
   return (
     <>
-      {/*// @ts-ignore */}
       <ReactKonva.Image
         height={height}
         image={image}

--- a/src/components/ImageViewer/Content/Stage/Layer/Layer.tsx
+++ b/src/components/ImageViewer/Content/Stage/Layer/Layer.tsx
@@ -48,7 +48,6 @@ export const Layer = ({ children }: LayerProps) => {
 
   return (
     <>
-      {/*// @ts-ignore */}
       <ReactKonva.Layer
         imageSmoothingEnabled={false}
         offset={offset}

--- a/src/components/ImageViewer/Content/Stage/PenAnnotationToolTip/PenAnnotationToolTip.tsx
+++ b/src/components/ImageViewer/Content/Stage/PenAnnotationToolTip/PenAnnotationToolTip.tsx
@@ -44,7 +44,6 @@ export const PenAnnotationToolTip = ({
 
   return (
     <>
-      {/*// @ts-ignore */}
       <ReactKonva.Ellipse
         radiusX={penSelectionBrushSize}
         radiusY={penSelectionBrushSize}

--- a/src/components/ImageViewer/Content/Stage/Selection/ColorSelection/ColorSelection.tsx
+++ b/src/components/ImageViewer/Content/Stage/Selection/ColorSelection/ColorSelection.tsx
@@ -23,9 +23,7 @@ export const ColorSelection = ({ operator }: ColorSelectionProps) => {
 
   return (
     <>
-      {/*// @ts-ignore */}
       <ReactKonva.Group>
-        {/*// @ts-ignore */}
         <ReactKonva.Image
           image={image}
           scale={{ x: stageScale, y: stageScale }}

--- a/src/components/ImageViewer/Content/Stage/Selection/EllipticalSelection/EllipticalSelection.tsx
+++ b/src/components/ImageViewer/Content/Stage/Selection/EllipticalSelection/EllipticalSelection.tsx
@@ -21,9 +21,7 @@ export const EllipticalSelection = ({ operator }: EllipticalSelectionProps) => {
 
   return (
     <>
-      {/*// @ts-ignore */}
       <ReactKonva.Group>
-        {/*// @ts-ignore */}
         <ReactKonva.Ellipse
           dash={[4, 2]}
           dashOffset={-dashOffset}
@@ -35,7 +33,6 @@ export const EllipticalSelection = ({ operator }: EllipticalSelectionProps) => {
           x={x}
           y={y}
         />
-        {/*// @ts-ignore */}
         <ReactKonva.Ellipse
           dash={[4 / stageScale, 2 / stageScale]}
           dashOffset={-dashOffset}

--- a/src/components/ImageViewer/Content/Stage/Selection/LassoSelection/LassoSelection.tsx
+++ b/src/components/ImageViewer/Content/Stage/Selection/LassoSelection/LassoSelection.tsx
@@ -18,9 +18,7 @@ export const LassoSelection = ({ operator }: LassoSelectionProps) => {
 
   return (
     <>
-      {/*// @ts-ignore */}
       <ReactKonva.Group>
-        {/*// @ts-ignore */}
         <ReactKonva.Circle
           fill="white"
           radius={3}
@@ -32,7 +30,6 @@ export const LassoSelection = ({ operator }: LassoSelectionProps) => {
 
         {operator.anchor && (
           <>
-            {/*// @ts-ignore */}
             <ReactKonva.Circle
               fill="black"
               radius={3}
@@ -43,14 +40,12 @@ export const LassoSelection = ({ operator }: LassoSelectionProps) => {
             />
           </>
         )}
-        {/*// @ts-ignore */}
         <ReactKonva.Line
           points={operator.buffer}
           scale={{ x: stageScale, y: stageScale }}
           stroke="black"
           strokeWidth={1 / stageScale}
         />
-        {/*// @ts-ignore */}
         <ReactKonva.Line
           dash={[4 / stageScale, 2 / stageScale]}
           dashOffset={-dashOffset}

--- a/src/components/ImageViewer/Content/Stage/Selection/MagneticSelection/MagneticSelection.tsx
+++ b/src/components/ImageViewer/Content/Stage/Selection/MagneticSelection/MagneticSelection.tsx
@@ -18,9 +18,7 @@ export const MagneticSelection = ({ operator }: MagneticSelectionProps) => {
 
   return (
     <>
-      {/*// @ts-ignore */}
       <ReactKonva.Group>
-        {/*// @ts-ignore */}
         <ReactKonva.Circle
           fill="white"
           radius={3}
@@ -31,7 +29,6 @@ export const MagneticSelection = ({ operator }: MagneticSelectionProps) => {
         />
         {operator.anchor && (
           <>
-            {/*// @ts-ignore */}
             <ReactKonva.Circle
               fill="black"
               radius={3}
@@ -42,14 +39,12 @@ export const MagneticSelection = ({ operator }: MagneticSelectionProps) => {
             />
           </>
         )}
-        {/*// @ts-ignore */}
         <ReactKonva.Line
           points={operator.buffer}
           scale={{ x: stageScale, y: stageScale }}
           stroke="black"
           strokeWidth={1 / stageScale}
         />
-        {/*// @ts-ignore */}
         <ReactKonva.Line
           dash={[4 / stageScale, 2 / stageScale]}
           scale={{ x: stageScale, y: stageScale }}

--- a/src/components/ImageViewer/Content/Stage/Selection/ObjectSelection/ObjectSelection.tsx
+++ b/src/components/ImageViewer/Content/Stage/Selection/ObjectSelection/ObjectSelection.tsx
@@ -23,9 +23,7 @@ export const ObjectSelection = ({ operator }: ObjectSelectionProps) => {
 
   return (
     <>
-      {/*// @ts-ignore */}
       <ReactKonva.Group>
-        {/*// @ts-ignore */}
         <ReactKonva.Rect
           dash={[4 / stageScale, 2 / stageScale]}
           dashOffset={-dashOffset}
@@ -37,7 +35,6 @@ export const ObjectSelection = ({ operator }: ObjectSelectionProps) => {
           x={x}
           y={y}
         />
-        {/*// @ts-ignore */}
         <ReactKonva.Rect
           dash={[4 / stageScale, 2 / stageScale]}
           dashOffset={-dashOffset}
@@ -49,7 +46,6 @@ export const ObjectSelection = ({ operator }: ObjectSelectionProps) => {
           x={x}
           y={y}
         />
-        {/*// @ts-ignore */}
         <ReactKonva.Line
           scale={{ x: stageScale, y: stageScale }}
           stroke="white"

--- a/src/components/ImageViewer/Content/Stage/Selection/PenSelection/PenSelection.tsx
+++ b/src/components/ImageViewer/Content/Stage/Selection/PenSelection/PenSelection.tsx
@@ -12,9 +12,7 @@ export const PenSelection = ({ operator }: PenSelectionProps) => {
   const stageScale = useSelector(stageScaleSelector);
   return (
     <>
-      {/*// @ts-ignore */}
       <ReactKonva.Group>
-        {/*// @ts-ignore */}
         <ReactKonva.Line
           points={operator.buffer}
           lineJoin="round"

--- a/src/components/ImageViewer/Content/Stage/Selection/PointerSelection/PointerSelection.tsx
+++ b/src/components/ImageViewer/Content/Stage/Selection/PointerSelection/PointerSelection.tsx
@@ -22,7 +22,6 @@ export const PointerSelection = () => {
 
   return (
     <>
-      {/*// @ts-ignore */}
       <ReactKonva.Rect
         dash={[4, 2]}
         dashOffset={-dashOffset}

--- a/src/components/ImageViewer/Content/Stage/Selection/PolygonalSelection/PolygonalSelection.tsx
+++ b/src/components/ImageViewer/Content/Stage/Selection/PolygonalSelection/PolygonalSelection.tsx
@@ -18,9 +18,7 @@ export const PolygonalSelection = ({ operator }: PolygonalSelectionProps) => {
 
   return (
     <>
-      {/*// @ts-ignore */}
       <ReactKonva.Group>
-        {/*// @ts-ignore */}
         <ReactKonva.Circle
           fill="white"
           radius={3}
@@ -32,7 +30,6 @@ export const PolygonalSelection = ({ operator }: PolygonalSelectionProps) => {
 
         {operator.anchor && (
           <>
-            {/*// @ts-ignore */}
             <ReactKonva.Circle
               fill="black"
               radius={3}
@@ -43,14 +40,12 @@ export const PolygonalSelection = ({ operator }: PolygonalSelectionProps) => {
             />
           </>
         )}
-        {/*// @ts-ignore */}
         <ReactKonva.Line
           points={operator.buffer}
           scale={{ x: stageScale, y: stageScale }}
           stroke="black"
           strokeWidth={1 / stageScale}
         />
-        {/*// @ts-ignore */}
         <ReactKonva.Line
           dash={[4 / stageScale, 2 / stageScale]}
           dashOffset={-dashOffset}

--- a/src/components/ImageViewer/Content/Stage/Selection/QuickSelection/QuickSelection.tsx
+++ b/src/components/ImageViewer/Content/Stage/Selection/QuickSelection/QuickSelection.tsx
@@ -27,9 +27,7 @@ export const QuickSelection = ({ operator }: QuickSelectionProps) => {
 
   return (
     <>
-      {/*// @ts-ignore */}
       <ReactKonva.Group>
-        {/*// @ts-ignore */}
         <ReactKonva.Image
           image={image}
           scale={{ x: stageScale, y: stageScale }}

--- a/src/components/ImageViewer/Content/Stage/Selection/RectangularSelection/RectangularSelection.tsx
+++ b/src/components/ImageViewer/Content/Stage/Selection/RectangularSelection/RectangularSelection.tsx
@@ -23,9 +23,7 @@ export const RectangularSelection = ({
 
   return (
     <>
-      {/*// @ts-ignore */}
       <ReactKonva.Group>
-        {/*// @ts-ignore */}
         <ReactKonva.Rect
           dash={[4 / stageScale, 2 / stageScale]}
           dashOffset={-dashOffset}
@@ -37,7 +35,6 @@ export const RectangularSelection = ({
           x={x}
           y={y}
         />
-        {/*// @ts-ignore */}
         <ReactKonva.Rect
           dash={[4 / stageScale, 2 / stageScale]}
           dashOffset={-dashOffset}

--- a/src/components/ImageViewer/Content/Stage/Selection/ZoomSelection/ZoomSelection.tsx
+++ b/src/components/ImageViewer/Content/Stage/Selection/ZoomSelection/ZoomSelection.tsx
@@ -15,9 +15,7 @@ export const ZoomSelection = ({}) => {
 
   return (
     <>
-      {/*// @ts-ignore */}
       <ReactKonva.Group>
-        {/*// @ts-ignore */}
         <ReactKonva.Rect
           dash={[4, 2]}
           dashOffset={-dashOffset}
@@ -28,7 +26,6 @@ export const ZoomSelection = ({}) => {
           x={minimum.x}
           y={minimum.y}
         />
-        {/*// @ts-ignore */}
         <ReactKonva.Rect
           dash={[4, 2]}
           dashOffset={-dashOffset}

--- a/src/components/ImageViewer/Content/Stage/Stage/Stage.tsx
+++ b/src/components/ImageViewer/Content/Stage/Stage/Stage.tsx
@@ -754,11 +754,9 @@ export const Stage = () => {
 
   return (
     <>
-      {/*// @ts-ignore */}
       <ReactReduxContext.Consumer>
         {({ store }) => (
           <>
-            {/*// @ts-ignore */}
             <ReactKonva.Stage
               draggable={draggable}
               height={stageHeight}
@@ -771,10 +769,8 @@ export const Stage = () => {
               width={stageWidth}
             >
               <Provider store={store}>
-                {/*// @ts-ignore */}
                 <DndProvider backend={HTML5Backend}>
                   <Layer>
-                    {/*// @ts-ignore */}
                     <Image ref={imageRef} />
 
                     <ZoomSelection />

--- a/src/components/ImageViewer/Content/Stage/Transformer/Transformer.tsx
+++ b/src/components/ImageViewer/Content/Stage/Transformer/Transformer.tsx
@@ -383,9 +383,7 @@ export const Transformer = ({
 
   return (
     <>
-      {/*// @ts-ignore */}
       <ReactKonva.Group>
-        {/*// @ts-ignore */}
         <ReactKonva.Transformer
           boundBoxFunc={boundingBoxFunc}
           onTransform={onTransform}
@@ -397,9 +395,7 @@ export const Transformer = ({
         />
         {selectedAnnotation && selectedAnnotations.length === 1 && (
           <>
-            {/*// @ts-ignore */}
             <ReactKonva.Group>
-              {/*// @ts-ignore */}
               <ReactKonva.Label
                 position={{
                   x: posX - 58,
@@ -410,7 +406,6 @@ export const Transformer = ({
                 onMouseEnter={onMouseEnter}
                 onMouseLeave={onMouseLeave}
               >
-                {/*// @ts-ignore */}
                 <ReactKonva.Tag
                   cornerRadius={3}
                   fill={"darkgreen"}
@@ -419,7 +414,6 @@ export const Transformer = ({
                   shadowBlur={10}
                   shadowOffset={{ x: 5, y: 5 }}
                 />
-                {/*// @ts-ignore */}
                 <ReactKonva.Text
                   fill={"white"}
                   fontSize={14}
@@ -427,7 +421,6 @@ export const Transformer = ({
                   text={"Confirm"}
                 />
               </ReactKonva.Label>
-              {/*// @ts-ignore */}
               <ReactKonva.Label
                 position={{
                   x: posX - 52,
@@ -438,7 +431,6 @@ export const Transformer = ({
                 onMouseEnter={onMouseEnter}
                 onMouseLeave={onMouseLeave}
               >
-                {/*// @ts-ignore */}
                 <ReactKonva.Tag
                   cornerRadius={3}
                   fill={"darkred"}
@@ -447,7 +439,6 @@ export const Transformer = ({
                   shadowBlur={10}
                   shadowOffset={{ x: 5, y: 5 }}
                 />
-                {/*// @ts-ignore */}
                 <ReactKonva.Text
                   fill={"white"}
                   fontSize={14}

--- a/src/components/ImageViewer/Content/Stage/Transformers/Transformers.tsx
+++ b/src/components/ImageViewer/Content/Stage/Transformers/Transformers.tsx
@@ -24,7 +24,6 @@ export const Transformers = ({ transformPosition }: TransformersProps) => {
       {selectedAnnotationsIds.map((annotationId, idx) => {
         return (
           <>
-            {/*// @ts-ignore */}
             <React.Fragment key={annotationId}>
               <Transformer
                 transformPosition={transformPosition}

--- a/src/components/ImageViewer/Help/HelpContent/HelpContent.tsx
+++ b/src/components/ImageViewer/Help/HelpContent/HelpContent.tsx
@@ -23,7 +23,6 @@ export const ManipulatingCanvasContent = () => {
     <>
       <br />
       <HelpWindowToolTitle toolName={"Hand tool"} letter={"H"}>
-        {/*// @ts-ignore */}
         <HandIcon />
       </HelpWindowToolTitle>
       <Typography>
@@ -34,7 +33,6 @@ export const ManipulatingCanvasContent = () => {
       <Divider />
       <br />
       <HelpWindowToolTitle toolName={"Zoom tool"} letter={"Z"}>
-        {/*// @ts-ignore */}
         <ZoomIcon />
       </HelpWindowToolTitle>
       <Typography>
@@ -52,7 +50,6 @@ export const ManipulatingCanvasContent = () => {
       <Divider />
       <br />
       <HelpWindowToolTitle toolName={"Intensity adjustment"} letter={"I"}>
-        {/*// @ts-ignore */}
         <ColorAdjustmentIcon />
       </HelpWindowToolTitle>
       <Typography>
@@ -170,7 +167,6 @@ export const MakingNewAnnotationsHelpContent = () => {
       <Divider />
       <br />
       <HelpWindowToolTitle toolName={"Rectangular annotation"} letter={"R"}>
-        {/*// @ts-ignore */}
         <RectangularSelectionIcon />
       </HelpWindowToolTitle>
       <Typography>
@@ -181,7 +177,6 @@ export const MakingNewAnnotationsHelpContent = () => {
       <Divider />
       <br />
       <HelpWindowToolTitle toolName={"Elliptical annotation"} letter={"E"}>
-        {/*// @ts-ignore */}
         <EllipticalSelectionIcon />
       </HelpWindowToolTitle>
       <Typography>
@@ -192,7 +187,6 @@ export const MakingNewAnnotationsHelpContent = () => {
       <Divider />
       <br />
       <HelpWindowToolTitle toolName={"Pen annotation"} letter={"D"}>
-        {/*// @ts-ignore */}
         <PenSelectionIcon />
       </HelpWindowToolTitle>
       <Typography>
@@ -204,7 +198,6 @@ export const MakingNewAnnotationsHelpContent = () => {
       <Divider />
       <br />
       <HelpWindowToolTitle toolName={"Lasso annotation"} letter={"L"}>
-        {/*// @ts-ignore */}
         <LassoSelectionIcon />
       </HelpWindowToolTitle>
       <Typography>
@@ -215,7 +208,6 @@ export const MakingNewAnnotationsHelpContent = () => {
       <Divider />
       <br />
       <HelpWindowToolTitle toolName={"Polygonal annotation"} letter={"P"}>
-        {/*// @ts-ignore */}
         <PolygonalSelectionIcon />
       </HelpWindowToolTitle>
       <Typography>
@@ -227,7 +219,6 @@ export const MakingNewAnnotationsHelpContent = () => {
       <Divider />
       <br />
       <HelpWindowToolTitle toolName={"Magnetic annotation"} letter={"M"}>
-        {/*// @ts-ignore */}
         <MagneticSelectionIcon />
       </HelpWindowToolTitle>
       <Typography>
@@ -239,7 +230,6 @@ export const MakingNewAnnotationsHelpContent = () => {
       <Divider />
       <br />
       <HelpWindowToolTitle toolName={"Color annotation"} letter={"C"}>
-        {/*// @ts-ignore */}
         <ColorSelectionIcon />
       </HelpWindowToolTitle>
       <Typography>
@@ -251,7 +241,6 @@ export const MakingNewAnnotationsHelpContent = () => {
       <Divider />
       <br />
       <HelpWindowToolTitle toolName={"Quick annotation"} letter={"Q"}>
-        {/*// @ts-ignore */}
         <QuickSelectionIcon />
       </HelpWindowToolTitle>
       <Typography>
@@ -268,7 +257,6 @@ export const ChangingAnnotationsHelpContent = () => {
     <>
       <br />
       <HelpWindowToolTitle toolName={"Select tool"} letter={"S"}>
-        {/*// @ts-ignore */}
         <SelectionIcon />
       </HelpWindowToolTitle>
       <Typography>

--- a/src/components/ImageViewer/ImageViewer/ImageViewer.tsx
+++ b/src/components/ImageViewer/ImageViewer/ImageViewer.tsx
@@ -111,7 +111,6 @@ export const ImageViewer = ({ image, onClose, open }: ImageViewerProps) => {
 
   return (
     <>
-      {/*// @ts-ignore */}
       <ThemeProvider theme={theme}>
         <Dialog fullScreen open={open} onClose={onClose}>
           <div className={classes.root}>

--- a/src/components/ImageViewer/ToolOptions/AnnotationMode/AnnotationMode/AnnotationMode.tsx
+++ b/src/components/ImageViewer/ToolOptions/AnnotationMode/AnnotationMode/AnnotationMode.tsx
@@ -63,13 +63,11 @@ export const AnnotationMode = () => {
                 edge="start"
                 icon={
                   <>
-                    {/*// @ts-ignore */}
                     <RadioUncheckedIcon />
                   </>
                 }
                 checkedIcon={
                   <>
-                    {/*// @ts-ignore */}
                     <RadioCheckedIcon />
                   </>
                 }
@@ -94,13 +92,11 @@ export const AnnotationMode = () => {
                 edge="start"
                 icon={
                   <>
-                    {/*// @ts-ignore */}
                     <RadioUncheckedIcon />
                   </>
                 }
                 checkedIcon={
                   <>
-                    {/*// @ts-ignore */}
                     <RadioCheckedIcon />
                   </>
                 }
@@ -127,13 +123,11 @@ export const AnnotationMode = () => {
                 edge="start"
                 icon={
                   <>
-                    {/*// @ts-ignore */}
                     <RadioUncheckedIcon />
                   </>
                 }
                 checkedIcon={
                   <>
-                    {/*// @ts-ignore */}
                     <RadioCheckedIcon />
                   </>
                 }
@@ -160,13 +154,11 @@ export const AnnotationMode = () => {
                 edge="start"
                 icon={
                   <>
-                    {/*// @ts-ignore */}
                     <RadioUncheckedIcon />
                   </>
                 }
                 checkedIcon={
                   <>
-                    {/*// @ts-ignore */}
                     <RadioCheckedIcon />
                   </>
                 }

--- a/src/components/ImageViewer/ToolOptions/ColorAdjustmentOptions/ChannelsList/ChannelsList.tsx
+++ b/src/components/ImageViewer/ToolOptions/ColorAdjustmentOptions/ChannelsList/ChannelsList.tsx
@@ -105,13 +105,11 @@ export const ChannelsList = ({
             edge="start"
             icon={
               <>
-                {/*// @ts-ignore */}
                 <CheckboxUncheckedIcon />
               </>
             }
             checkedIcon={
               <>
-                {/*// @ts-ignore */}
                 <CheckboxCheckedIcon />
               </>
             }

--- a/src/components/ImageViewer/ToolOptions/InvertAnnotation/InvertAnnotation.tsx
+++ b/src/components/ImageViewer/ToolOptions/InvertAnnotation/InvertAnnotation.tsx
@@ -29,7 +29,6 @@ export const InvertAnnotation = () => {
         <ListItemIcon>
           <SvgIcon>
             <>
-              {/*// @ts-ignore */}
               <InvertSelectionIcon />
             </>
           </SvgIcon>

--- a/src/components/ImageViewer/ToolOptions/PointerSelectionOptions/PointerSelectionOptions.tsx
+++ b/src/components/ImageViewer/ToolOptions/PointerSelectionOptions/PointerSelectionOptions.tsx
@@ -75,7 +75,6 @@ export const PointerSelectionOptions = () => {
           <ListItemIcon>
             <SvgIcon>
               <>
-                {/*// @ts-ignore */}
                 <InvertSelectionIcon />
               </>
             </SvgIcon>
@@ -87,7 +86,6 @@ export const PointerSelectionOptions = () => {
           <ListItemIcon>
             <SvgIcon>
               <>
-                {/*// @ts-ignore */}
                 <InvertSelectionIcon />
               </>
             </SvgIcon>

--- a/src/components/ImageViewer/ToolOptions/SampleList/SampleList.tsx
+++ b/src/components/ImageViewer/ToolOptions/SampleList/SampleList.tsx
@@ -37,13 +37,11 @@ export const SampleList = () => {
             edge="start"
             icon={
               <>
-                {/*// @ts-ignore */}
                 <CheckboxUncheckedIcon />
               </>
             }
             checkedIcon={
               <>
-                {/*// @ts-ignore */}
                 <CheckboxCheckedIcon />
               </>
             }
@@ -62,13 +60,11 @@ export const SampleList = () => {
             edge="start"
             icon={
               <>
-                {/*// @ts-ignore */}
                 <CheckboxUncheckedIcon />
               </>
             }
             checkedIcon={
               <>
-                {/*// @ts-ignore */}
                 <CheckboxCheckedIcon />
               </>
             }
@@ -87,13 +83,11 @@ export const SampleList = () => {
             edge="start"
             icon={
               <>
-                {/*// @ts-ignore */}
                 <CheckboxUncheckedIcon />
               </>
             }
             checkedIcon={
               <>
-                {/*// @ts-ignore */}
                 <CheckboxCheckedIcon />
               </>
             }

--- a/src/components/ImageViewer/ToolOptions/ToolOptions/ToolOptions.tsx
+++ b/src/components/ImageViewer/ToolOptions/ToolOptions/ToolOptions.tsx
@@ -47,7 +47,6 @@ export const ToolOptions = () => {
       description: "Nam a facilisis velit, sit amet interdum ante. In sodales.",
       icon: (
         <>
-          {/*// @ts-ignore */}
           <ColorAdjustmentIcon />
         </>
       ),
@@ -59,7 +58,6 @@ export const ToolOptions = () => {
       description: "Nam a facilisis velit, sit amet interdum ante. In sodales.",
       icon: (
         <>
-          {/*// @ts-ignore */}
           <RectangularSelectionIcon />
         </>
       ),
@@ -67,7 +65,6 @@ export const ToolOptions = () => {
       name: "Rectangular selection",
       options: (
         <>
-          {/*// @ts-ignore */}
           <RectangularAnnotationOptions />
         </>
       ),
@@ -76,7 +73,6 @@ export const ToolOptions = () => {
       description: "Nam a facilisis velit, sit amet interdum ante. In sodales.",
       icon: (
         <>
-          {/*// @ts-ignore */}
           <EllipticalSelectionIcon />
         </>
       ),
@@ -84,7 +80,6 @@ export const ToolOptions = () => {
       name: "Elliptical selection",
       options: (
         <>
-          {/*// @ts-ignore */}
           <EllipticalAnnotationOptions />
         </>
       ),
@@ -93,7 +88,6 @@ export const ToolOptions = () => {
       description: "Nam a facilisis velit, sit amet interdum ante. In sodales.",
       icon: (
         <>
-          {/*// @ts-ignore */}
           <PenSelectionIcon />
         </>
       ),
@@ -105,7 +99,6 @@ export const ToolOptions = () => {
       description: "Nam a facilisis velit, sit amet interdum ante. In sodales.",
       icon: (
         <>
-          {/*// @ts-ignore */}
           <LassoSelectionIcon />
         </>
       ),
@@ -113,7 +106,6 @@ export const ToolOptions = () => {
       name: "Lasso selection",
       options: (
         <>
-          {/*// @ts-ignore */}
           <LassoAnnotationOptions />
         </>
       ),
@@ -122,7 +114,6 @@ export const ToolOptions = () => {
       description: "Nam a facilisis velit, sit amet interdum ante. In sodales.",
       icon: (
         <>
-          {/*// @ts-ignore */}
           <PolygonalSelectionIcon />
         </>
       ),
@@ -130,7 +121,6 @@ export const ToolOptions = () => {
       name: "Polygonal selection",
       options: (
         <>
-          {/*// @ts-ignore */}
           <PolygonalAnnotationOptions />
         </>
       ),
@@ -139,7 +129,6 @@ export const ToolOptions = () => {
       description: "Nam a facilisis velit, sit amet interdum ante. In sodales.",
       icon: (
         <>
-          {/*// @ts-ignore */}
           <MagneticSelectionIcon />
         </>
       ),
@@ -147,7 +136,6 @@ export const ToolOptions = () => {
       name: "Magnetic selection",
       options: (
         <>
-          {/*// @ts-ignore */}
           <MagneticAnnotationOptions />
         </>
       ),
@@ -156,7 +144,6 @@ export const ToolOptions = () => {
       description: "Nam a facilisis velit, sit amet interdum ante. In sodales.",
       icon: (
         <>
-          {/*// @ts-ignore */}
           <ColorSelectionIcon />
         </>
       ),
@@ -164,7 +151,6 @@ export const ToolOptions = () => {
       name: "Color selection",
       options: (
         <>
-          {/*// @ts-ignore */}
           <ColorAnnotationOptions />
         </>
       ),
@@ -173,7 +159,6 @@ export const ToolOptions = () => {
       description: "Nam a facilisis velit, sit amet interdum ante. In sodales.",
       icon: (
         <>
-          {/*// @ts-ignore */}
           <QuickSelectionIcon />
         </>
       ),
@@ -181,7 +166,6 @@ export const ToolOptions = () => {
       name: "Quick selection",
       options: (
         <>
-          {/*// @ts-ignore */}
           <QuickAnnotationOptions />
         </>
       ),
@@ -190,7 +174,6 @@ export const ToolOptions = () => {
       description: "Nam a facilisis velit, sit amet interdum ante. In sodales.",
       icon: (
         <>
-          {/*// @ts-ignore */}
           <ObjectSelectionIcon />
         </>
       ),
@@ -198,7 +181,6 @@ export const ToolOptions = () => {
       name: "Object selection",
       options: (
         <>
-          {/*// @ts-ignore */}
           <ObjectAnnotationOptions />
         </>
       ),
@@ -207,7 +189,6 @@ export const ToolOptions = () => {
       description: "Nam a facilisis velit, sit amet interdum ante. In sodales.",
       icon: (
         <>
-          {/*// @ts-ignore */}
           <HandIcon />
         </>
       ),
@@ -215,7 +196,6 @@ export const ToolOptions = () => {
       name: "Hand",
       options: (
         <>
-          {/*// @ts-ignore */}
           <HandToolOptions />
         </>
       ),
@@ -224,7 +204,6 @@ export const ToolOptions = () => {
       description: "Description of zoom here.",
       icon: (
         <>
-          {/*// @ts-ignore */}
           <ZoomIcon />
         </>
       ),
@@ -232,7 +211,6 @@ export const ToolOptions = () => {
       name: "Zoom",
       options: (
         <>
-          {/*// @ts-ignore */}
           <ZoomOptions />
         </>
       ),
@@ -241,7 +219,6 @@ export const ToolOptions = () => {
       description: "Description of pointer here.",
       icon: (
         <>
-          {/*// @ts-ignore */}
           <ObjectSelectionIcon />
         </>
       ),
@@ -249,7 +226,6 @@ export const ToolOptions = () => {
       name: "Pointer",
       options: (
         <>
-          {/*// @ts-ignore */}
           <PointerSelectionOptions />
         </>
       ),

--- a/src/components/ImageViewer/ToolOptions/ZoomOptions/ZoomOptions.tsx
+++ b/src/components/ImageViewer/ToolOptions/ZoomOptions/ZoomOptions.tsx
@@ -252,13 +252,11 @@ export const ZoomOptions = () => {
                   edge="start"
                   icon={
                     <>
-                      {/*// @ts-ignore */}
                       <RadioUncheckedIcon />
                     </>
                   }
                   checkedIcon={
                     <>
-                      {/*// @ts-ignore */}
                       <RadioCheckedIcon />
                     </>
                   }
@@ -281,13 +279,11 @@ export const ZoomOptions = () => {
                   edge="start"
                   icon={
                     <>
-                      {/*// @ts-ignore */}
                       <RadioUncheckedIcon />
                     </>
                   }
                   checkedIcon={
                     <>
-                      {/*// @ts-ignore */}
                       <RadioCheckedIcon />
                     </>
                   }
@@ -306,20 +302,17 @@ export const ZoomOptions = () => {
 
       <ListItem button dense onClick={onAutomaticCenteringChange}>
         <ListItemIcon>
-          {/*// @ts-ignore */}
           <Checkbox
             checked={options.automaticCentering}
             disableRipple
             edge="start"
             icon={
               <>
-                {/*// @ts-ignore */}
                 <CheckboxUncheckedIcon />
               </>
             }
             checkedIcon={
               <>
-                {/*// @ts-ignore */}
                 <RadioCheckedIcon />
               </>
             }

--- a/src/components/ImageViewer/Tools/Tools/Tools.tsx
+++ b/src/components/ImageViewer/Tools/Tools/Tools.tsx
@@ -50,7 +50,6 @@ export const Tools = () => {
         }}
         selected={activeOperation === OperationType.Hand}
       >
-        {/*// @ts-ignore */}
         <HandIcon />
       </Tool>
 
@@ -65,7 +64,6 @@ export const Tools = () => {
         }}
         selected={activeOperation === OperationType.Zoom}
       >
-        {/*// @ts-ignore */}
         <ZoomIcon />
       </Tool>
 
@@ -80,7 +78,6 @@ export const Tools = () => {
         }}
         selected={activeOperation === OperationType.ColorAdjustment}
       >
-        {/*// @ts-ignore */}
         <ColorAdjustmentIcon />
       </Tool>
 
@@ -97,7 +94,6 @@ export const Tools = () => {
         }}
         selected={activeOperation === OperationType.Pointer}
       >
-        {/*// @ts-ignore */}
         <SelectionIcon />
       </Tool>
 
@@ -113,7 +109,6 @@ export const Tools = () => {
         }}
         selected={activeOperation === OperationType.RectangularAnnotation}
       >
-        {/*// @ts-ignore */}
         <RectangularSelectionIcon />
       </Tool>
 
@@ -128,7 +123,6 @@ export const Tools = () => {
         }}
         selected={activeOperation === OperationType.EllipticalAnnotation}
       >
-        {/*// @ts-ignore */}
         <EllipticalSelectionIcon />
       </Tool>
 
@@ -143,7 +137,6 @@ export const Tools = () => {
         }}
         selected={activeOperation === OperationType.PolygonalAnnotation}
       >
-        {/*// @ts-ignore */}
         <PolygonalSelectionIcon />
       </Tool>
 
@@ -160,7 +153,6 @@ export const Tools = () => {
         }}
         selected={activeOperation === OperationType.PenAnnotation}
       >
-        {/*// @ts-ignore */}
         <PenSelectionIcon />
       </Tool>
 
@@ -177,7 +169,6 @@ export const Tools = () => {
         }}
         selected={activeOperation === OperationType.LassoAnnotation}
       >
-        {/*// @ts-ignore */}
         <LassoSelectionIcon />
       </Tool>
 
@@ -192,7 +183,6 @@ export const Tools = () => {
         }}
         selected={activeOperation === OperationType.MagneticAnnotation}
       >
-        {/*// @ts-ignore */}
         <MagneticSelectionIcon />
       </Tool>
 
@@ -209,7 +199,6 @@ export const Tools = () => {
         }}
         selected={activeOperation === OperationType.ColorAnnotation}
       >
-        {/*// @ts-ignore */}
         <ColorSelectionIcon />
       </Tool>
 
@@ -224,7 +213,6 @@ export const Tools = () => {
         }}
         selected={activeOperation === OperationType.QuickAnnotation}
       >
-        {/*// @ts-ignore */}
         <QuickSelectionIcon />
       </Tool>
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,10 +14,8 @@ const theme = createTheme();
 
 ReactDOM.render(
   <Provider store={productionStore}>
-    {/*// @ts-ignore */}
     <ThemeProvider theme={theme}>
       <StyledEngineProvider injectFirst>
-        {/*// @ts-ignore */}
         <DndProvider backend={HTML5Backend}>
           <Application />
         </DndProvider>

--- a/src/store/coroutines/classifier/fit.ts
+++ b/src/store/coroutines/classifier/fit.ts
@@ -3,6 +3,30 @@ import { FitOptions } from "../../../types/FitOptions";
 import * as tensorflow from "@tensorflow/tfjs";
 import * as tfvis from "@tensorflow/tfjs-vis";
 
+/*
+ * Fix for issue #90.
+ * TL;DR: Preact pollutes the global namespace, and now we have to too.
+ *
+ * An unfortunately dirty solution to a nasty mix of using react alongside tfjs-vis, which in turn uses preact.
+ * Preact v8 populates the global namespace with an extension of the Element type.
+ * React also has an Element type, which it extends as ReactElement.
+ * The two do no mix well, and cause all sorts of weird type issues whenever tfjs-vis is imported.
+ * tfjs is not maintained so have not updated to v10+, and is also not likely to accept any pull requests.
+ * Hence the messy solution below.
+ *
+ * See: https://github.com/preactjs/preact/issues/2748
+ * Or see: line 129 of "node_modules/preact/src/preact.d.ts"
+ */
+declare global {
+  namespace React {
+    interface ReactElement {
+      nodeName: any;
+      attributes: any;
+      children: any;
+    }
+  }
+}
+
 export const fit = async (
   compiled: LayersModel,
   data: {


### PR DESCRIPTION
- Primary "fix" is in "src/store/coroutines/classifier/fit.ts"
- Overrides Preact's (used by tfjs-vis package) global namespace pollution with our own global namespace pollution (yuck)
- All other modifications are removals of {/*// @ts-ignore */}
- All empty tags remain, but may be replaced with React.Fragment without type errors.