### PR TITLE
Some fixes on the recently pulled hotkey functionality

### DIFF
--- a/src/components/annotator/AnnotatorDrawer/SaveMenu/SaveAnnotationProjectDialog.tsx
+++ b/src/components/annotator/AnnotatorDrawer/SaveMenu/SaveAnnotationProjectDialog.tsx
@@ -56,7 +56,7 @@ export const SaveAnnotationProjectDialog = ({
       onSaveAllAnnotations();
     },
     HotkeyView.SaveAnnotationProjectDialog,
-    { enabled: open },
+    { enableOnTags: ["INPUT"] },
     [onSaveAllAnnotations]
   );
 

--- a/src/components/annotator/ImageContent/Stage/Stage/SoundEvents.tsx
+++ b/src/components/annotator/ImageContent/Stage/Stage/SoundEvents.tsx
@@ -34,7 +34,7 @@ export const SoundEvents = memo(() => {
   useHotkeys(
     "enter",
     () => {
-      playCreateAnnotationSoundEffect();
+      soundEnabled && playCreateAnnotationSoundEffect();
     },
     HotkeyView.Annotator,
     [soundEnabled, creeateAnnotationSound]
@@ -43,7 +43,7 @@ export const SoundEvents = memo(() => {
   useHotkeys(
     "escape, backspace, delete",
     () => {
-      playDeleteAnnotationSoundEffect();
+      soundEnabled && playDeleteAnnotationSoundEffect();
     },
     HotkeyView.Annotator,
     [soundEnabled, deleteAnnotationSound]

--- a/src/components/categories/CreateCategory/CreateCategoryDialog/CreateCategoryDialog.tsx
+++ b/src/components/categories/CreateCategory/CreateCategoryDialog/CreateCategoryDialog.tsx
@@ -104,7 +104,7 @@ export const CreateCategoryDialog = ({
       onCreate();
     },
     HotkeyView.CreateCategoryDialog,
-    { enabled: open },
+    { enableOnTags: ["INPUT"] },
     [onCreate]
   );
 

--- a/src/components/categories/DeleteAllCategories/DeleteAllCategoriesDialog/DeleteAllCategoriesDialog.tsx
+++ b/src/components/categories/DeleteAllCategories/DeleteAllCategoriesDialog/DeleteAllCategoriesDialog.tsx
@@ -68,6 +68,7 @@ export const DeleteAllCategoriesDialog = ({
       onDeleteAllCategories();
     },
     HotkeyView.DeleteAllCategoriesDialog,
+    { enableOnTags: ["INPUT"] },
     [onDeleteAllCategories]
   );
 

--- a/src/components/categories/DeleteCategory/DeleteCategoryDialog/DeleteCategoryDialog.tsx
+++ b/src/components/categories/DeleteCategory/DeleteCategoryDialog/DeleteCategoryDialog.tsx
@@ -38,6 +38,7 @@ export const DeleteCategoryDialog = ({
       onDelete();
     },
     HotkeyView.DeleteCategoryDialog,
+    { enableOnTags: ["INPUT"] },
     [onDelete]
   );
 

--- a/src/components/categories/EditCategory/EditCategoryDialog/EditCategoryDialog.tsx
+++ b/src/components/categories/EditCategory/EditCategoryDialog/EditCategoryDialog.tsx
@@ -78,6 +78,7 @@ export const EditCategoryDialog = ({
       onEdit();
     },
     HotkeyView.EditCategoryDialog,
+    { enableOnTags: ["INPUT"] },
 
     [onEdit]
   );

--- a/src/components/common/ImageShapeDialog/ImageShapeDialog.tsx
+++ b/src/components/common/ImageShapeDialog/ImageShapeDialog.tsx
@@ -87,6 +87,7 @@ export const ImageShapeDialog = ({
       uploadImages();
     },
     HotkeyView.ImageShapeDialog,
+    { enableOnTags: ["INPUT"] },
     [uploadImages]
   );
 

--- a/src/components/common/ImportTensorflowModelDialog/ImportTensorflowModelDialog.tsx
+++ b/src/components/common/ImportTensorflowModelDialog/ImportTensorflowModelDialog.tsx
@@ -123,6 +123,7 @@ export const ImportTensorflowModelDialog = ({
     "enter",
     () => dispatchModelToStore(),
     HotkeyView.ImportTensorflowModelDialog,
+    { enableOnTags: ["INPUT"] },
     [dispatchModelToStore]
   );
 

--- a/src/components/file-io/NewProjectDialog/NewProjectDialog.tsx
+++ b/src/components/file-io/NewProjectDialog/NewProjectDialog.tsx
@@ -62,9 +62,13 @@ export const NewProjectDialog = ({ onClose, open }: NewProjectDialogProps) => {
     onClose();
   };
 
-  useHotkeys("enter", () => onCreateNewProject(), HotkeyView.NewProjectDialog, [
-    onCreateNewProject,
-  ]);
+  useHotkeys(
+    "enter",
+    () => onCreateNewProject(),
+    HotkeyView.NewProjectDialog,
+    { enableOnTags: ["INPUT"] },
+    [onCreateNewProject]
+  );
 
   return (
     <Dialog fullWidth maxWidth={"xs"} onClose={closeDialog} open={open}>

--- a/src/components/file-io/SaveFittedModelDialog/SaveFittedModelDialog.tsx
+++ b/src/components/file-io/SaveFittedModelDialog/SaveFittedModelDialog.tsx
@@ -51,6 +51,7 @@ export const SaveFittedModelDialog = ({
       onSaveClassifierClick();
     },
     HotkeyView.SaveFittedModelDialog,
+    { enableOnTags: ["INPUT"] },
     [onSaveClassifierClick]
   );
 

--- a/src/components/file-io/SaveProjectDialog/SaveProjectDialog.tsx
+++ b/src/components/file-io/SaveProjectDialog/SaveProjectDialog.tsx
@@ -70,6 +70,7 @@ export const SaveProjectDialog = ({
       onSaveProjectClick();
     },
     HotkeyView.SaveProjectDialog,
+    { enableOnTags: ["INPUT"] },
     [onSaveProjectClick]
   );
 

--- a/src/components/main/DeleteImagesDialog/DeleteImagesDialog.tsx
+++ b/src/components/main/DeleteImagesDialog/DeleteImagesDialog.tsx
@@ -38,6 +38,7 @@ export const DeleteImagesDialog = ({
       onDelete();
     },
     HotkeyView.DeleteImagesDialog,
+    { enableOnTags: ["INPUT"] },
     [onDelete]
   );
 

--- a/src/hooks/useHotkeys/useHotkeys.ts
+++ b/src/hooks/useHotkeys/useHotkeys.ts
@@ -76,7 +76,6 @@ export function useHotkeys(
   const memoisedCallback = useCallback(
     (keyboardEvent: KeyboardEvent, hotkeysEvent: HotkeysEvent) => {
       if (filter && !filter(keyboardEvent)) {
-        console.log("filtered");
         return !filterPreventDefault;
       }
 
@@ -94,7 +93,6 @@ export function useHotkeys(
         (hotkeyView.length && hotkeyView.includes(currentHotkeyView)) ||
         (!hotkeyView.length && hotkeyView === currentHotkeyView)
       ) {
-        console.log(true);
         callback(keyboardEvent, hotkeysEvent);
         return true;
       }

--- a/src/hooks/useKeyboardShortcuts/useAnnotatorKeyboardShortcuts.tsx
+++ b/src/hooks/useKeyboardShortcuts/useAnnotatorKeyboardShortcuts.tsx
@@ -1,7 +1,5 @@
-import * as _ from "lodash";
 import { useDispatch, useSelector } from "react-redux";
 import { useHotkeys } from "hooks";
-import useSound from "use-sound";
 
 import { annotationCategoriesSelector } from "store/project";
 import {
@@ -23,8 +21,6 @@ import {
   ToolType,
 } from "types";
 import { AnnotationTool } from "annotator/image/Tool";
-import createAnnotationSoundEffect from "annotator/sounds/pop-up-on.mp3";
-import deleteAnnotationSoundEffect from "annotator/sounds/pop-up-off.mp3";
 
 type useAnnotatorHotkeysProps = {
   annotations: AnnotationType[];

--- a/src/hooks/useKeyboardShortcuts/useAnnotatorKeyboardShortcuts.tsx
+++ b/src/hooks/useKeyboardShortcuts/useAnnotatorKeyboardShortcuts.tsx
@@ -82,8 +82,6 @@ export const useAnnotatorKeyboardShortcuts = ({
       })
     );
 
-    if (soundEnabled) playCreateAnnotationSoundEffect();
-
     deselectAnnotation();
 
     if (selectionMode !== AnnotationModeType.New)
@@ -98,13 +96,6 @@ export const useAnnotatorKeyboardShortcuts = ({
     deselectAllAnnotations();
     deselectAllTransformers();
   };
-
-  const [playCreateAnnotationSoundEffect] = useSound(
-    createAnnotationSoundEffect
-  );
-  const [playDeleteAnnotationSoundEffect] = useSound(
-    deleteAnnotationSoundEffect
-  );
 
   const soundEnabled = useSelector(soundEnabledSelector);
   /*
@@ -288,10 +279,6 @@ export const useAnnotatorKeyboardShortcuts = ({
       deselectAllAnnotations();
       deselectAllTransformers();
 
-      if (!_.isEmpty(annotations) && soundEnabled) {
-        playDeleteAnnotationSoundEffect();
-      }
-
       deselectAnnotation();
 
       if (toolType !== ToolType.Zoom) return;
@@ -311,10 +298,6 @@ export const useAnnotatorKeyboardShortcuts = ({
       );
       deselectAllAnnotations();
       deselectAllTransformers();
-
-      if (!_.isEmpty(annotations) && soundEnabled) {
-        playDeleteAnnotationSoundEffect();
-      }
 
       deselectAnnotation();
     },

--- a/src/hooks/useKeyboardShortcuts/useAnnotatorKeyboardShortcuts.tsx
+++ b/src/hooks/useKeyboardShortcuts/useAnnotatorKeyboardShortcuts.tsx
@@ -101,10 +101,11 @@ export const useAnnotatorKeyboardShortcuts = ({
   /*
    * Select category (1-9)
    */
+
   useHotkeys(
     "shift+1,shift+2,shit+3,shift+4,shift+5,shift+6,shift+7,shift+8,shift+9",
     (event: KeyboardEvent, handler) => {
-      const index = parseInt(handler.key) - 1;
+      const index = parseInt(handler.key.slice(-1));
 
       const selectedCategory = annotationCategories[index];
 

--- a/src/hooks/usePointer/usePointer.ts
+++ b/src/hooks/usePointer/usePointer.ts
@@ -66,7 +66,6 @@ export const usePointer = () => {
   );
 
   const onMouseDown = (position: { x: number; y: number }) => {
-    console.log("mouseDown");
     dispatch(
       setPointerSelection({
         pointerSelection: {

--- a/src/store/classifier/coroutines/cropUtil.test.ts
+++ b/src/store/classifier/coroutines/cropUtil.test.ts
@@ -23,8 +23,8 @@ it("padToMatch", async () => {
   const result = profile.result as tf.Tensor<tf.Rank.R3>;
   const padded = result.arraySync();
 
-  console.log(`newBytes: ${profile.newBytes}`);
-  console.log(`newTensors: ${profile.newTensors}`);
+  // console.log(`newBytes: ${profile.newBytes}`);
+  // console.log(`newTensors: ${profile.newTensors}`);
 
   const expected = [
     [
@@ -185,7 +185,7 @@ describe("matchedCropPad - random", () => {
       [1.0, 1.0],
     ];
 
-    console.log(cropCoords);
+    // console.log(cropCoords);
     matchedCropExpectations(dims, cropCoords, cropCoordsExpected);
   });
 
@@ -207,7 +207,7 @@ describe("matchedCropPad - random", () => {
       [0.66666, 1.0],
     ];
 
-    console.log(cropCoords);
+    // console.log(cropCoords);
     matchedCropExpectations(dims, cropCoords, cropCoordsExpected);
   });
 
@@ -229,7 +229,7 @@ describe("matchedCropPad - random", () => {
       [1.0, 1.0],
     ];
 
-    console.log(cropCoords);
+    // console.log(cropCoords);
     matchedCropExpectations(dims, cropCoords, cropCoordsExpected);
   });
 });
@@ -280,7 +280,7 @@ describe("matchedCropPad - center", () => {
 
     const cropCoordsExpected = [0.25, 0.0, 0.75, 1.0];
 
-    console.log(cropCoords);
+    // console.log(cropCoords);
     matchedCropExpectations(dims, cropCoords, cropCoordsExpected);
   });
 
@@ -297,7 +297,7 @@ describe("matchedCropPad - center", () => {
 
     const cropCoordsExpected = [0.25, 1 / 8, 0.75, 7 / 8];
 
-    console.log(cropCoords);
+    // console.log(cropCoords);
     matchedCropExpectations(dims, cropCoords, cropCoordsExpected);
   });
 
@@ -314,7 +314,7 @@ describe("matchedCropPad - center", () => {
 
     const cropCoordsExpected = [0.0, 0.0, 1.0, 1.0];
 
-    console.log(cropCoords);
+    // console.log(cropCoords);
     matchedCropExpectations(dims, cropCoords, cropCoordsExpected);
   });
 });

--- a/src/store/classifier/coroutines/evaluateClassifier.test.ts
+++ b/src/store/classifier/coroutines/evaluateClassifier.test.ts
@@ -284,7 +284,7 @@ it("evaluateClassifier", async () => {
     f1Score: 0.6666666865348816,
   };
 
-  console.log(result);
+  // console.log(result);
 
   // expect(result.confusionMatrix).toEqual(expectedResults.confusionMatrix);
   // expect(result.accuracy).toBeCloseTo(expectedResults.accuracy, 5);

--- a/src/utils/getStackTrace.ts
+++ b/src/utils/getStackTrace.ts
@@ -8,7 +8,7 @@ export const getStackTraceFromError = async (error: Error): Promise<string> => {
       .map((stackFrame) => stackFrame.toString())
       .join("\n");
   } catch (error) {
-    console.log("Could not resolve stacktrace", error);
+    console.error("Could not resolve stacktrace", error);
   }
 
   return stacktrace;


### PR DESCRIPTION
- Remove some lingering console.log statements
- Create/Delete annotation sound effects were playing twice on enter/delete, remove the hotkeys from `useAnnotatorKeyboardShortcuts` (they need to be in `SoundEffects` because of the AudioContext issue
- Fix "shift-num" hot key in annotator so that it slices out the actual index