### PR TITLE
[add] Add analytics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -40,6 +40,14 @@
     -->
     <title>Piximi</title>
 
+    <!-- Plausible Analytics (page view count) -->
+    <script
+      defer
+      data-domain="piximi.app"
+      src="https://plausible.io/js/script.js"
+    ></script>
+    <!-- end analytics -->
+
     <!-- Start Single Page Apps for GitHub Pages -->
     <script type="text/javascript">
       // Single Page Apps for GitHub Pages


### PR DESCRIPTION
adds plausible analytics, which does not identify users and is GDPR compliant for simple, anonymous page view counting

supersedes #435 