### PR TITLE
Make annotation tool always available

### DIFF
--- a/src/annotator-tools/BlankAnnotationTool/BlankAnnotationTool.ts
+++ b/src/annotator-tools/BlankAnnotationTool/BlankAnnotationTool.ts
@@ -1,0 +1,41 @@
+import { Image } from "image-js";
+import { AnnotationTool } from "../AnnotationTool";
+import { AnnotationStateType } from "types";
+
+/*
+ * Rather than having operator possibly undefined,
+ * in `useAnnotationTool` we have a "Dummy" Annotation Tool
+ * which implements the AnnotationTool Abstract class
+ * but via dummy methods, or minimal methods
+ * That way we don't have to do annotationTool checks
+ * in the Stage, its children component and its hooks
+ */
+export class BlankAnnotationTool extends AnnotationTool {
+  constructor(image?: Image) {
+    const defaultImage = image ?? new Image();
+    super(defaultImage);
+  }
+
+  deselect() {
+    this.origin = undefined;
+    this.annotation = undefined;
+
+    this.setBlank();
+  }
+
+  onMouseDown(position: { x: number; y: number }) {
+    if (this.annotationState === AnnotationStateType.Annotated) return;
+
+    this.setAnnotating();
+  }
+
+  onMouseMove(position: { x: number; y: number }) {
+    if (this.annotationState !== AnnotationStateType.Annotating) return;
+  }
+
+  onMouseUp(position: { x: number; y: number }) {
+    if (this.annotationState !== AnnotationStateType.Annotating) return;
+
+    this.setAnnotated();
+  }
+}

--- a/src/annotator-tools/BlankAnnotationTool/index.ts
+++ b/src/annotator-tools/BlankAnnotationTool/index.ts
@@ -1,0 +1,1 @@
+export { BlankAnnotationTool } from "./BlankAnnotationTool";

--- a/src/components/annotator/Stage/Annotations/AnnotationTransformer/AnnotationTransformer.tsx
+++ b/src/components/annotator/Stage/Annotations/AnnotationTransformer/AnnotationTransformer.tsx
@@ -25,7 +25,7 @@ import {
 
 import useSound from "use-sound";
 
-import { AnnotationModeType, AnnotationStateType } from "types";
+import { AnnotationModeType } from "types";
 
 import { AnnotationTool } from "annotator-tools";
 import createAnnotationSoundEffect from "data/sounds/pop-up-on.mp3";
@@ -42,7 +42,7 @@ const labelPosition = {
 
 type AnnotationTransformerProps = {
   annotationId: string;
-  annotationTool?: AnnotationTool;
+  annotationTool: AnnotationTool;
 };
 
 export const AnnotationTransformer = ({
@@ -78,16 +78,7 @@ export const AnnotationTransformer = ({
   );
 
   const clearAnnotation = () => {
-    if (annotationTool) {
-      annotationTool.deselect();
-    } else {
-      dispatch(
-        annotatorSlice.actions.setAnnotationState({
-          annotationState: AnnotationStateType.Blank,
-          annotationTool: annotationTool,
-        })
-      );
-    }
+    annotationTool.deselect();
     batch(() => {
       dispatch(
         imageViewerSlice.actions.setWorkingAnnotation({ annotation: undefined })

--- a/src/components/annotator/Stage/Selection/Selection.tsx
+++ b/src/components/annotator/Stage/Selection/Selection.tsx
@@ -27,13 +27,11 @@ import {
 } from "annotator-tools";
 
 type SelectionProps = {
-  tool?: Tool;
-  toolType?: ToolType;
+  tool: Tool;
+  toolType: ToolType;
 };
 
 export const Selection = ({ tool, toolType }: SelectionProps) => {
-  if (!toolType || !tool) return <></>;
-
   switch (toolType) {
     case ToolType.ColorAnnotation:
       return <ColorSelection operator={tool as ColorAnnotationTool} />;

--- a/src/components/annotator/Stage/Stage.tsx
+++ b/src/components/annotator/Stage/Stage.tsx
@@ -73,7 +73,7 @@ export const Stage = ({
     setCurrentMousePosition,
     positionByStage,
     pixelColor,
-  } = usePointerLocation(imageRef, stageRef!, annotationTool?.image);
+  } = usePointerLocation(imageRef, stageRef!, annotationTool.image);
 
   const {
     handleMouseUp,

--- a/src/components/annotator/ToolOptions/InvertAnnotation/InvertAnnotation.tsx
+++ b/src/components/annotator/ToolOptions/InvertAnnotation/InvertAnnotation.tsx
@@ -24,7 +24,7 @@ export const InvertAnnotation = () => {
   const workingAnnotationEntity = useSelector(selectWorkingAnnotation);
 
   const onInvertClick = () => {
-    if (!annotationTool || !workingAnnotationEntity.saved) return;
+    if (!workingAnnotationEntity.saved) return;
     const workingAnnotation = {
       ...workingAnnotationEntity.saved,
       ...workingAnnotationEntity.changes,

--- a/src/hooks/useAnnotationState/useAnnotationState.ts
+++ b/src/hooks/useAnnotationState/useAnnotationState.ts
@@ -47,7 +47,7 @@ export const useAnnotationState = (annotationTool: AnnotationTool) => {
         })
       );
       if (selectionMode !== AnnotationModeType.New) return;
-      annotationTool?.annotate(
+      annotationTool.annotate(
         selectedCategory!,
         activeImagePlane!,
         activeImageId!
@@ -75,7 +75,6 @@ export const useAnnotationState = (annotationTool: AnnotationTool) => {
     return func;
   }, [annotationTool, dispatch]);
   useEffect(() => {
-    if (!annotationTool) return;
     annotationTool.registerOnAnnotatedHandler(onAnnotated);
     annotationTool.registerOnAnnotatingHandler(onAnnotating);
     annotationTool.registerOnDeselectHandler(onDeselect);

--- a/src/hooks/useAnnotationTool/useAnnotationTool.ts
+++ b/src/hooks/useAnnotationTool/useAnnotationTool.ts
@@ -25,10 +25,13 @@ import {
   RectangularAnnotationTool,
   ThresholdAnnotationTool,
 } from "annotator-tools";
+import { BlankAnnotationTool } from "annotator-tools/BlankAnnotationTool";
 
 export const useAnnotationTool = () => {
-  const [operator, setOperator] = useState<AnnotationTool>();
   const [image, setImage] = useState<ImageJS.Image>();
+  const [operator, setOperator] = useState<AnnotationTool>(
+    new BlankAnnotationTool()
+  );
 
   const src = useSelector(selectActiveImageSrc);
   const operation = useSelector(selectToolType);
@@ -94,6 +97,10 @@ export const useAnnotationTool = () => {
         setOperator(new RectangularAnnotationTool(image));
 
         return;
+      default:
+        setOperator(new BlankAnnotationTool(image));
+
+        return;
     }
   }, [operation, image]);
 
@@ -115,7 +122,7 @@ export const useAnnotationTool = () => {
   }, [operator, quickSelectionRegionSize, penSelectionBrushSize, stageScale]);
 
   return {
-    annotationTool: operator!,
+    annotationTool: operator,
     ToolSelecton: {
       /*!(
                 annotationState !== AnnotationStateType.Annotating &&

--- a/src/hooks/useKeyboardShortcuts/useAnnotatorKeyboardShortcuts.tsx
+++ b/src/hooks/useKeyboardShortcuts/useAnnotatorKeyboardShortcuts.tsx
@@ -27,7 +27,7 @@ import {
 import { AnnotationTool } from "annotator-tools";
 
 type useAnnotatorHotkeysProps = {
-  annotationTool: AnnotationTool | undefined;
+  annotationTool: AnnotationTool;
   deleteAnnotations: (
     annotationIds: Array<string>,
     activeAnnotations: Array<DecodedAnnotationType>
@@ -66,7 +66,6 @@ export const useAnnotatorKeyboardShortcuts = ({
   const confirmAnnotations = () => {
     if (
       !workingAnnotationEntity.saved ||
-      !annotationTool ||
       annotationTool.annotationState === AnnotationStateType.Annotating ||
       !activeImageId
     )
@@ -295,7 +294,7 @@ export const useAnnotatorKeyboardShortcuts = ({
     [
       activeImageId,
       annotationTool,
-      annotationTool?.annotationState,
+      annotationTool.annotationState,
       selectedAnnotations,
       activeAnnotations,
       selectionMode,
@@ -308,8 +307,6 @@ export const useAnnotatorKeyboardShortcuts = ({
   useHotkeys(
     "escape",
     () => {
-      if (!annotationTool) return;
-
       deselectAllAnnotations();
 
       deselectAnnotation();

--- a/src/hooks/usePointerLocation/usePointerLocation.ts
+++ b/src/hooks/usePointerLocation/usePointerLocation.ts
@@ -6,7 +6,7 @@ import { Point } from "types";
 export const usePointerLocation = (
   imageRef: React.MutableRefObject<Konva.Image | null>,
   stageRef: React.RefObject<Konva.Stage | null>,
-  originalImage: ImageJS.Image | undefined
+  originalImage: ImageJS.Image
 ) => {
   const [absolutePosition, setAbsolutePosition] = useState<Point>();
   const [positionByStage, setPositionByStage] = useState<Point>();
@@ -15,7 +15,7 @@ export const usePointerLocation = (
 
   const getPositionFromImage = useCallback(
     (position: Point): Point | undefined => {
-      if (!imageRef || !imageRef.current || !originalImage) return;
+      if (!imageRef || !imageRef.current) return;
 
       const transform = imageRef.current.getAbsoluteTransform().copy();
 
@@ -24,7 +24,7 @@ export const usePointerLocation = (
       const imageOffset = transform.point(position);
 
       return {
-        x: (imageOffset.x / imageRef.current.width()) * originalImage?.width,
+        x: (imageOffset.x / imageRef.current.width()) * originalImage.width,
         y: (imageOffset.y / imageRef.current.height()) * originalImage.height,
       };
     },
@@ -42,7 +42,7 @@ export const usePointerLocation = (
     []
   );
   const setCurrentMousePosition = useCallback(() => {
-    if (!stageRef.current || !originalImage) return;
+    if (!stageRef.current) return;
     const position = stageRef.current.getPointerPosition();
 
     if (!position) return;
@@ -84,7 +84,7 @@ export const usePointerLocation = (
     setAbsolutePosition(absolute);
   }, [stageRef, getRelativePosition, originalImage, imageRef]);
   useEffect(() => {
-    if (!absolutePosition?.x || outOfBounds || !originalImage) return;
+    if (!absolutePosition?.x || outOfBounds) return;
 
     let y: number;
     /* For some reason the full range of x values work, but only y < height  work

--- a/src/hooks/useStageHandlers/useStageHandlers.ts
+++ b/src/hooks/useStageHandlers/useStageHandlers.ts
@@ -79,18 +79,8 @@ export const useStageHandlers = (
   } = useZoom(stageRef?.current);
 
   const deselectAnnotation = useCallback(() => {
-    if (!annotationTool) {
-      console.log("deselect me");
-      dispatch(
-        annotatorSlice.actions.setAnnotationState({
-          annotationState: AnnotationStateType.Blank,
-          annotationTool,
-        })
-      );
-      return;
-    }
     annotationTool.deselect();
-  }, [annotationTool, dispatch]);
+  }, [annotationTool]);
 
   const deleteAnnotations = (
     annotationIds: Array<string>,
@@ -397,7 +387,7 @@ export const useStageHandlers = (
           return;
         }
       }
-      if (!annotationTool || outOfBounds) return;
+      if (outOfBounds) return;
       annotationTool.onMouseDown(absolutePosition);
     };
     const throttled = throttle(func, 5);
@@ -434,7 +424,6 @@ export const useStageHandlers = (
       } else if (toolType === ToolType.Pointer) {
         handlePointerMouseMove(absolutePosition!);
       } else {
-        if (!annotationTool) return;
         annotationTool.onMouseMove(absolutePosition!);
       }
     };
@@ -487,7 +476,6 @@ export const useStageHandlers = (
       } else if (toolType === ToolType.Pointer) {
         handlePointerMouseUp(absolutePosition);
       } else {
-        if (!annotationTool) return;
         if (toolType === ToolType.ObjectAnnotation) {
           await (annotationTool as ObjectAnnotationTool).onMouseUp(
             absolutePosition

--- a/src/store/annotator/annotatorListeners.ts
+++ b/src/store/annotator/annotatorListeners.ts
@@ -11,6 +11,7 @@ import { getCompleteEntity, getDeferredProperty } from "store/entities/utils";
 import { encodeAnnotation } from "utils/annotator";
 //import { dataSlice } from "store/data";
 import { imageViewerSlice } from "store/imageViewer";
+import { BlankAnnotationTool } from "annotator-tools/BlankAnnotationTool";
 
 export const annotatorMiddleware = createListenerMiddleware();
 
@@ -23,7 +24,10 @@ startAppListening({
     const { imageViewer, data, annotator } = listenerAPI.getState();
     const { annotationState, annotationTool } = action.payload;
 
-    if (!annotationTool || annotationState !== AnnotationStateType.Annotated)
+    if (
+      annotationTool instanceof BlankAnnotationTool ||
+      annotationState !== AnnotationStateType.Annotated
+    )
       return;
     const selectionMode = annotator.selectionMode;
     const activeImageId = imageViewer.activeImageId;

--- a/src/store/annotator/annotatorSlice.ts
+++ b/src/store/annotator/annotatorSlice.ts
@@ -28,7 +28,7 @@ export const annotatorSlice = createSlice({
       state,
       action: PayloadAction<{
         annotationState: AnnotationStateType;
-        annotationTool: AnnotationTool | undefined;
+        annotationTool: AnnotationTool;
       }>
     ) {
       state.annotationState = action.payload.annotationState;

--- a/src/utils/annotator/point-operations/point-operations.ts
+++ b/src/utils/annotator/point-operations/point-operations.ts
@@ -60,6 +60,8 @@ export function interpolateX(yScan: number, edge: Edge) {
 export function computeBoundingBoxFromContours(
   contour: Array<Point>
 ): [number, number, number, number] {
+  if (contour.length === 0) return [0, 0, 0, 0];
+
   const xValues = contour.map((point) => point.x);
   const yValues = contour.map((point) => point.y);
   return [


### PR DESCRIPTION
`Stage`, its children components, and hooks do a lot of checking for `annotationTool === undefined`; moreover `useAnnotationTool` [forcefully returns](https://github.com/piximi/piximi/pull/482/files#diff-838a05bcb9746ac74762118f91ece635e1f2c0dfb07d732a1d1aacc3ba31979dL118) `annotationTool` as `AnnotationTool` despite possibly being undefined.

Change it so `useAnnotationTool` always does return a defined object by creating a [dummy annotation tool](https://github.com/piximi/piximi/pull/482/files#diff-b1ad6737ef7ebd5c07ecfe825617a0436e87a7bacf9ea8a0049c60e319f874fbR13) object, and remove downstream `annotationTool` checks.

Also clean up `AnnotationTool` class for clarity by adding access modifiers.