### PR TITLE
Memoize model idx selectors

### DIFF
--- a/src/store/classifier/selectors/classifierSelectedModelIdxSelector.ts
+++ b/src/store/classifier/selectors/classifierSelectedModelIdxSelector.ts
@@ -1,13 +1,14 @@
+import { createSelector } from "@reduxjs/toolkit";
 import { Classifier } from "types";
 import { availableClassifierModels } from "types/ModelType";
 
-export const classifierSelectedModelIdxSelector = ({
-  classifier,
-}: {
-  classifier: Classifier;
-}) => {
-  return {
-    idx: classifier.selectedModelIdx,
-    model: availableClassifierModels[classifier.selectedModelIdx],
-  };
-};
+const selectedIdxSelector = ({ classifier }: { classifier: Classifier }) =>
+  classifier.selectedModelIdx;
+
+export const classifierSelectedModelIdxSelector = createSelector(
+  selectedIdxSelector,
+  (idx) => ({
+    idx,
+    model: availableClassifierModels[idx],
+  })
+);

--- a/src/store/segmenter/selectors/segmenterModelIdxSelector.ts
+++ b/src/store/segmenter/selectors/segmenterModelIdxSelector.ts
@@ -1,13 +1,17 @@
+import { createSelector } from "@reduxjs/toolkit";
 import { SegmenterStoreType } from "types";
 import { availableSegmenterModels } from "types/ModelType";
 
-export const segmenterModelIdxSelector = ({
+const selectedIdxSelector = ({
   segmenter,
 }: {
   segmenter: SegmenterStoreType;
-}) => {
-  return {
-    idx: segmenter.selectedModelIdx,
-    model: availableSegmenterModels[segmenter.selectedModelIdx],
-  };
-};
+}) => segmenter.selectedModelIdx;
+
+export const segmenterModelIdxSelector = createSelector(
+  selectedIdxSelector,
+  (idx) => ({
+    idx,
+    model: availableSegmenterModels[idx],
+  })
+);


### PR DESCRIPTION
wraps model w/ idx selectors in `createSelector` to avoid new objects and object refs from being generated on selector firing

@Andrea-Papaleo I ended up just wrapping existing selectors with `createSelector`. The other approach of changing the model selectors ended up creating a lot of tedious `selectedModel.model.xyz` downstream. Most components don't care about the `model idx`.