### PR TITLE
Make Cellpose warning more explicit

### DIFF
--- a/src/components/dialogs/ImportTensorflowModelDialog/ImportTensorflowModelDialog.tsx
+++ b/src/components/dialogs/ImportTensorflowModelDialog/ImportTensorflowModelDialog.tsx
@@ -200,7 +200,8 @@ export const ImportTensorflowModelDialog = ({
           sx={{ mb: 2 }}
         >
           This model performs inference in the cloud ☁️; images will leave your
-          machine.
+          machine. This requires internet access and may take time. Please choose
+          another option if your data is sensitive and should not be transmitted.
         </Alert>
       </Collapse>
       <DialogTitle>

--- a/src/components/dialogs/ImportTensorflowModelDialog/ImportTensorflowModelDialog.tsx
+++ b/src/components/dialogs/ImportTensorflowModelDialog/ImportTensorflowModelDialog.tsx
@@ -199,7 +199,7 @@ export const ImportTensorflowModelDialog = ({
           }
           sx={{ mb: 2 }}
         >
-          This model performs inference in the cloud ☁️
+          This model performs inference in the cloud ☁️; images will leave your machine. 
         </Alert>
       </Collapse>
       <DialogTitle>

--- a/src/components/dialogs/ImportTensorflowModelDialog/ImportTensorflowModelDialog.tsx
+++ b/src/components/dialogs/ImportTensorflowModelDialog/ImportTensorflowModelDialog.tsx
@@ -199,7 +199,8 @@ export const ImportTensorflowModelDialog = ({
           }
           sx={{ mb: 2 }}
         >
-          This model performs inference in the cloud ☁️; images will leave your machine. 
+          This model performs inference in the cloud ☁️; images will leave your
+          machine.
         </Alert>
       </Collapse>
       <DialogTitle>

--- a/src/components/dialogs/ImportTensorflowModelDialog/ImportTensorflowModelDialog.tsx
+++ b/src/components/dialogs/ImportTensorflowModelDialog/ImportTensorflowModelDialog.tsx
@@ -200,8 +200,9 @@ export const ImportTensorflowModelDialog = ({
           sx={{ mb: 2 }}
         >
           This model performs inference in the cloud ☁️; images will leave your
-          machine. This requires internet access and may take time. Please choose
-          another option if your data is sensitive and should not be transmitted.
+          machine. This requires internet access and may take time. Please
+          choose another option if your data is sensitive and should not be
+          transmitted.
         </Alert>
       </Collapse>
       <DialogTitle>


### PR DESCRIPTION
Unless you understand Piximi's architecture well, it's not clear why this is different than other modes. If anything, I think we could be more explicit here about both 1) requires internet access and 2) not suitable for data that cannot be sent over the internet, but I wasn't sure if other changes would need to be made to the component to then ie make the box taller.