### PR TITLE
Fix tab crash on stardist multi-image predict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ FROM node:16.13-bullseye-slim
 # Use python 3.8, node 16 (LTS, latest), debian 11 (slim)
 # Needed if including installation of @tensorflow/tfjs-node
 # FROM nikolaik/python-nodejs:python3.8-nodejs16-bullseye
-# ENV PYTHON="/usr/local/bin/python"
+
+ENV PYTHON="/usr/local/bin/python"
+
+RUN apt-get update && apt-get install -y git
 
 # Change working directory
 WORKDIR /piximi
@@ -15,15 +18,16 @@ ENV PATH="./node_modules/.bin:$PATH"
 # Set production environment for yarn
 ENV NODE_ENV="production"
 
-# Install dependencies
-COPY package.json .
-RUN yarn install
-
 # Copy source code
+# cannot copy over only package.json before yarn install
+# yarn install has data dependencies in prepare script
+# and src/examples/data
 COPY . .
 
+RUN yarn install
+
 # https://stackoverflow.com/questions/62663167/dockerizing-react-in-production-mode-fatal-error-ineffective-mark-compacts-nea
-ENV GENERATE_SOURCEMAP false
+ENV GENERATE_SOURCEMAP=false
 
 # Build the project
 RUN yarn run build
@@ -34,4 +38,4 @@ EXPOSE 3000
 
 # Launch application
 # CMD ["yarn", "run", "BROWSER=none", "react-scripts", "start"]
-CMD ["react-scripts", "start"]
+CMD ["yarn", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use node 16 (LTS, latest), debian 11 (slim)
-FROM node:16.13-bullseye-slim
+FROM node:16.20-bullseye-slim AS build
 
 # Use python 3.8, node 16 (LTS, latest), debian 11 (slim)
 # Needed if including installation of @tensorflow/tfjs-node
@@ -15,27 +15,34 @@ WORKDIR /piximi
 # Make module binaries available (e.g. react-scripts)
 ENV PATH="./node_modules/.bin:$PATH"
 
-# Set production environment for yarn
-ENV NODE_ENV="production"
-
 # Copy source code
 # cannot copy over only package.json before yarn install
 # yarn install has data dependencies in prepare script
 # and src/examples/data
 COPY . .
 
-RUN yarn install
+RUN yarn install --no-lockfile
 
 # https://stackoverflow.com/questions/62663167/dockerizing-react-in-production-mode-fatal-error-ineffective-mark-compacts-nea
 ENV GENERATE_SOURCEMAP=false
+ENV TSC_COMPILE_ON_ERROR=true
+ENV ESLINT_NO_DEV_ERRORS=true
+ENV DISABLE_ESLINT_PLUGIN=true
 
 # Build the project
 RUN yarn run build
 # RUN NODE_OPTIONS="--max-old-space-size=8192" yarn build
 
+FROM node:16.20-bullseye-slim AS production
+
+COPY --from=build /piximi/ /piximi/
+
+WORKDIR /piximi
+
+RUN yarn global add serve
+
 # Expose API port to the outside
 EXPOSE 3000
 
 # Launch application
-# CMD ["yarn", "run", "BROWSER=none", "react-scripts", "start"]
-CMD ["yarn", "run", "start"]
+CMD ["serve", "-s", "build"]

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "test": "react-scripts test --env=./src/utils/models/tests/custom-test-env.js",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "prepare": "husky install; node scripts/prepare",
+    "prepare": "husky install; node scripts/prepare.js",
     "prune-dead": "ts-prune",
     "no-console-logs": "./scripts/checkConsoleLogs.sh"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/redux-logger": "^3.0.8",
     "@types/uuid": "^8.3.3",
     "dicom-parser": "^1.8.13",
-    "dicom.ts": "^1.0.5",
+    "dicom.ts": "~1.0.5",
     "file-saver": "^2.0.5",
     "fp-ts": "^2.13.1",
     "i18next": "19.0.0",

--- a/src/components/dialogs/ImportTensorflowModelDialog/ImportTensorflowModelDialog.tsx
+++ b/src/components/dialogs/ImportTensorflowModelDialog/ImportTensorflowModelDialog.tsx
@@ -172,7 +172,12 @@ export const ImportTensorflowModelDialog = ({
 
   useEffect(() => {
     if (modelTask === ModelTask.Segmentation) {
-      if (selectedModel && selectedModel.requiredChannels !== projectChannels) {
+      if (
+        selectedModel &&
+        selectedModel.requiredChannels !== undefined &&
+        projectChannels !== undefined &&
+        selectedModel.requiredChannels !== projectChannels
+      ) {
         setInvalidModel(true);
       } else {
         setInvalidModel(false);

--- a/src/store/segmenter/segmenterListeners.ts
+++ b/src/store/segmenter/segmenterListeners.ts
@@ -346,6 +346,13 @@ async function handleError(
     stackTrace,
   };
 
+  if (process.env.NODE_ENV !== "production") {
+    console.error(description);
+    if (stackTrace) {
+      console.error(stackTrace);
+    }
+  }
+
   listenerAPI.dispatch(
     applicationSettingsSlice.actions.updateAlertState({
       alertState: alertState,

--- a/src/utils/file-io/types.ts
+++ b/src/utils/file-io/types.ts
@@ -66,4 +66,4 @@ export interface ImageFileShapeInfo extends ImageShapeInfo {
   ext: MIMEType;
 }
 
-export type LoadCB = (laodPercent: number, loadMessage: string) => void;
+export type LoadCB = (loadPercent: number, loadMessage: string) => void;

--- a/src/utils/models/segmentation/AbstractSegmenter/AbstractSegmenter.ts
+++ b/src/utils/models/segmentation/AbstractSegmenter/AbstractSegmenter.ts
@@ -11,6 +11,7 @@ import {
 import { TrainingCallbacks } from "../../types";
 import { OldCategory, Kind, AnnotationObject } from "store/data/types";
 import { logger } from "utils/common/helpers";
+import { LoadCB } from "utils/file-io/types";
 
 export type OrphanedAnnotationObject = Omit<
   AnnotationObject,
@@ -29,9 +30,9 @@ export abstract class Segmenter extends Model {
     super.dispose();
   }
 
-  public abstract predict():
-    | OrphanedAnnotationObject[][]
-    | Promise<OrphanedAnnotationObject[][]>;
+  public abstract predict(
+    loadCb?: LoadCB
+  ): OrphanedAnnotationObject[][] | Promise<OrphanedAnnotationObject[][]>;
 
   /*
    * Concrete classes must keep track of their inference categories somehow,

--- a/src/utils/models/segmentation/Cellpose/Callpose.ts
+++ b/src/utils/models/segmentation/Cellpose/Callpose.ts
@@ -10,11 +10,12 @@ import {
   OrphanedAnnotationObject,
 } from "../AbstractSegmenter/AbstractSegmenter";
 import { predictCellpose } from "./predictCellpose";
-import { generateUUID, logger } from "utils/common/helpers";
+import { generateUUID } from "utils/common/helpers";
 import { FitOptions } from "../../types";
 import { ModelTask } from "../../enums";
 import { getImageSlice } from "utils/common/tensorHelpers";
 import { Kind, ImageObject } from "store/data/types";
+import { LoadCB } from "utils/file-io/types";
 
 type LoadInferenceDataArgs = {
   fitOptions: FitOptions;
@@ -115,7 +116,7 @@ export class Cellpose extends Segmenter {
     }
   }
 
-  public async predict() {
+  public async predict(loadCb?: LoadCB) {
     if (!this._model) {
       throw Error(`"${this.name}" Model not loaded`);
     }
@@ -141,8 +142,12 @@ export class Cellpose extends Segmenter {
         this._config
       );
       annotations.push(annotObj);
-      // TODO: replace with progress animation callback
-      logger(`${idx + 1} of ${infT.length} images processed`);
+      if (loadCb) {
+        loadCb(
+          (idx + 1) / infT.length,
+          `${idx + 1} of ${infT.length} images predicted`
+        );
+      }
     }
 
     return annotations;

--- a/src/utils/models/segmentation/Cellpose/Callpose.ts
+++ b/src/utils/models/segmentation/Cellpose/Callpose.ts
@@ -132,7 +132,7 @@ export class Cellpose extends Segmenter {
 
     const annotations: Array<OrphanedAnnotationObject[]> = [];
     for await (const imTensor of infT) {
-      // imTensor disposed in _predictOne
+      // imTensor disposed in predictCellpose
       const annotObj = await predictCellpose(
         imTensor,
         this._fgKind!.id,

--- a/src/utils/models/segmentation/Cellpose/Callpose.ts
+++ b/src/utils/models/segmentation/Cellpose/Callpose.ts
@@ -10,7 +10,7 @@ import {
   OrphanedAnnotationObject,
 } from "../AbstractSegmenter/AbstractSegmenter";
 import { predictCellpose } from "./predictCellpose";
-import { generateUUID } from "utils/common/helpers";
+import { generateUUID, logger } from "utils/common/helpers";
 import { FitOptions } from "../../types";
 import { ModelTask } from "../../enums";
 import { getImageSlice } from "utils/common/tensorHelpers";
@@ -131,7 +131,7 @@ export class Cellpose extends Segmenter {
     const infT = await this._inferenceDataset.toArray();
 
     const annotations: Array<OrphanedAnnotationObject[]> = [];
-    for await (const imTensor of infT) {
+    for await (const [idx, imTensor] of infT.entries()) {
       // imTensor disposed in predictCellpose
       const annotObj = await predictCellpose(
         imTensor,
@@ -141,6 +141,8 @@ export class Cellpose extends Segmenter {
         this._config
       );
       annotations.push(annotObj);
+      // TODO: replace with progress animation callback
+      logger(`${idx + 1} of ${infT.length} images processed`);
     }
 
     return annotations;

--- a/src/utils/models/segmentation/Cellpose/Callpose.ts
+++ b/src/utils/models/segmentation/Cellpose/Callpose.ts
@@ -85,9 +85,7 @@ export class Cellpose extends Segmenter {
   ): void {
     this._inferenceDataset = tfdata
       .generator(this._sampleGenerator(images))
-      .batch(
-        preprocessingArgs.fitOptions.batchSize
-      ) as tfdata.Dataset<Tensor4D>;
+      .batch(1) as tfdata.Dataset<Tensor4D>;
 
     if (preprocessingArgs.kinds) {
       if (preprocessingArgs.kinds.length !== 1)

--- a/src/utils/models/segmentation/Stardist/AbstractStardist.ts
+++ b/src/utils/models/segmentation/Stardist/AbstractStardist.ts
@@ -6,7 +6,7 @@ import {
 } from "../AbstractSegmenter/AbstractSegmenter";
 import { preprocessStardist } from "./preprocessStardist";
 import { predictStardist } from "./predictStardist";
-import { generateUUID } from "utils/common/helpers";
+import { generateUUID, logger } from "utils/common/helpers";
 import { LoadInferenceDataArgs } from "../../types";
 import { Kind, ImageObject } from "store/data/types";
 
@@ -122,6 +122,8 @@ export abstract class Stardist extends Segmenter {
         this._inferenceDataDims![idx]
       );
       annotations.push(annotObj);
+      // TODO: replace with progress animation callback
+      logger(`${idx + 1} of ${infT.length} images processed`);
     }
 
     return annotations;

--- a/src/utils/models/segmentation/Stardist/AbstractStardist.ts
+++ b/src/utils/models/segmentation/Stardist/AbstractStardist.ts
@@ -6,9 +6,10 @@ import {
 } from "../AbstractSegmenter/AbstractSegmenter";
 import { preprocessStardist } from "./preprocessStardist";
 import { predictStardist } from "./predictStardist";
-import { generateUUID, logger } from "utils/common/helpers";
+import { generateUUID } from "utils/common/helpers";
 import { LoadInferenceDataArgs } from "../../types";
 import { Kind, ImageObject } from "store/data/types";
+import { LoadCB } from "utils/file-io/types";
 
 export const KIND_NAME = "stardist_nucleus";
 /*
@@ -85,7 +86,7 @@ export abstract class Stardist extends Segmenter {
     }
   }
 
-  public async predict() {
+  public async predict(loadCb?: LoadCB) {
     if (!this._model) {
       throw Error(`"${this.name}" Model not loaded`);
     }
@@ -122,8 +123,12 @@ export abstract class Stardist extends Segmenter {
         this._inferenceDataDims![idx]
       );
       annotations.push(annotObj);
-      // TODO: replace with progress animation callback
-      logger(`${idx + 1} of ${infT.length} images processed`);
+      if (loadCb) {
+        loadCb(
+          (idx + 1) / infT.length,
+          `${idx + 1} of ${infT.length} images predicted`
+        );
+      }
     }
 
     return annotations;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7938,7 +7938,7 @@ dicom-parser@^1.8.13:
   resolved "https://registry.yarnpkg.com/dicom-parser/-/dicom-parser-1.8.21.tgz#916fdc77776367976b8457cad462b5b7cf74eaea"
   integrity sha512-lYCweHQDsC8UFpXErPlg86Px2A8bay0HiUY+wzoG3xv5GzgqVHU3lziwSc/Gzn7VV7y2KeP072SzCviuOoU02w==
 
-dicom.ts@^1.0.5:
+dicom.ts@~1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/dicom.ts/-/dicom.ts-1.0.6.tgz#928b7e434ac2af285c61430e64b78ebf834a90eb"
   integrity sha512-Rpb/MuBWu2cT3499oV47Wfsq3ulbkNoKVddInwOjd+Lea9n5kk/e3/Xtkii0Tl2OXgaIx6x9qclaoVz4jMidyQ==


### PR DESCRIPTION
- when running Stardist's predict on multiple images (e.g. 26 images of 1 channel, 640x640, 16 bit) inference would crash the tab of the browser (reproduced on intel and m1 macbooks)
- crash would often happen directly on first, sometimes second image
- moving from awaiting Promise.all on mapped array to for of awaiting and appending to array seems to alleviate whatever memory congestion problem was present
- resolves #575 
- resolves #579 