### PR TITLE
[fix] kind dialog not closing

### DIFF
--- a/src/components/dialogs/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/src/components/dialogs/ConfirmationDialog/ConfirmationDialog.tsx
@@ -54,11 +54,16 @@ export const ConfirmationDialog = ({
 
   useHotkeys(
     "enter",
-    () => {
+    (keyboardEvent) => {
+      keyboardEvent.preventDefault();
       !confirmDisabled && handleConfirm();
     },
     HotkeyContext.ConfirmationDialog,
-    { enableOnTags: disableHotkeyOnInput ? [] : ["INPUT"], enabled: isOpen },
+    {
+      enableOnTags: disableHotkeyOnInput ? [] : ["INPUT"],
+      enabled: isOpen,
+      filterPreventDefault: false,
+    },
     [handleConfirm, confirmDisabled]
   );
 

--- a/src/components/dialogs/CreateKindDialog/CreateKindDialog.tsx
+++ b/src/components/dialogs/CreateKindDialog/CreateKindDialog.tsx
@@ -3,7 +3,7 @@ import { dataSlice } from "store/data/dataSlice";
 import { ConfirmationDialog } from "../ConfirmationDialog";
 import { Box, TextField } from "@mui/material";
 import { selectAllKindIds } from "store/data/selectors";
-import { ChangeEvent, useCallback, useState } from "react";
+import { ChangeEvent, useCallback, useEffect, useState } from "react";
 import { generateUnknownCategory } from "utils/common/helpers";
 import { Kind } from "store/data/types";
 
@@ -32,7 +32,11 @@ export const CreateKindDialog = ({
 
   const handleNameChange = (event: ChangeEvent<HTMLInputElement>) => {
     setName(event.target.value);
-    validateInput(event.target.value);
+  };
+
+  const handleClose = () => {
+    setName("");
+    onClose();
   };
 
   const validateInput = useCallback(
@@ -84,12 +88,17 @@ export const CreateKindDialog = ({
       );
     });
     secondaryAction && secondaryAction();
-    onClose();
+
+    handleClose();
   };
+
+  useEffect(() => {
+    validateInput(name);
+  }, [existingKinds, name, validateInput]);
 
   return (
     <ConfirmationDialog
-      onClose={onClose}
+      onClose={handleClose}
       isOpen={open}
       title={"Create Kind"}
       content={
@@ -115,7 +124,7 @@ export const CreateKindDialog = ({
           />
         </Box>
       }
-      onConfirm={() => handleConfirm()}
+      onConfirm={handleConfirm}
       confirmDisabled={isInvalidName}
     />
   );


### PR DESCRIPTION
Weird bug where hitting enter resulted in a call to the `onOpen` function attached to the "add kinds" button. It was strange that it wasn't also happening when creating the kind in the project view, even though they use the same dialog component. Checking the call tree I saw that theres an additional `onClick` event being fired after the `onKeyDown` event which runs `onOpen` again. Calling `preventDefault()` on the  keyboardEvent stops that from happening,  even though the add button with the `onClick` isn't a parent of the dialog.