### PR TITLE
fix issue #631: Update README.md

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake .

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Builds the app for production to the `build` folder.<br />
 
 Runs the tests. Note that for tests using tensorflow you need to specify the custom environment:
 
-`yarn test --env=./src/utils/common/models/utils/custom-test-env.js`<br />
+`yarn test --env=./src/utils/models/tests/custom-test-env.js`<br />
 
 ## Docker
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733220138,
+        "narHash": "sha256-Yh5XZ9yVurrcYdNTSWxYgW4+EJ0pcOqgM1043z9JaRc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bcb68885668cccec12276bbb379f8f2557aa06ce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,59 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    systems.url = "github:nix-systems/default";
+    flake-utils.url = "github:numtide/flake-utils";
+    flake-utils.inputs.systems.follows = "systems";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, systems, ... } @ inputs:
+      flake-utils.lib.eachDefaultSystem (system:
+        let
+            pkgs = import nixpkgs {
+              system = system;
+              config.allowUnfree = true;
+              config.cudaSupport = true;
+            };
+
+
+            libList = [
+                # Add needed packages here
+                pkgs.stdenv.cc.cc
+                pkgs.libuuid
+              ];
+        in
+          with pkgs;
+        {
+          devShells = {
+              default = let 
+              in mkShell {
+                    NIX_LD = runCommand "ld.so" {} ''
+                        ln -s "$(cat '${pkgs.stdenv.cc}/nix-support/dynamic-linker')" $out
+                      '';
+                    NIX_LD_LIBRARY_PATH = lib.makeLibraryPath libList;
+                    packages = [
+                      yarn
+                      husky
+                      # pkgs.nodePackages.husky
+                      # nodejs
+                    ]
+                    ++ libList; 
+                    shellHook = ''
+                        export LD_LIBRARY_PATH=$NIX_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
+
+                    '';
+                  };
+              };
+        }
+      );
+}
+
+                        # export PATH=./node_modules/.bin:$PATH
+                        # # Add local node_modules binaries to PATH
+                        # export PATH=./node_modules/.bin:$PATH
+
+                        # # Automatically install Husky hooks if package.json exists
+                        # if [ -f package.json ] && [ -d node_modules/husky ]; then
+                        #   echo "Setting up Husky hooks..."
+                        #   ./node_modules/.bin/husky install
+                        # fi

--- a/new_file_test.py
+++ b/new_file_test.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/new_file_test.py
+++ b/new_file_test.py
@@ -1,1 +1,0 @@
-#!/usr/bin/env python3

--- a/scripts/checkConsoleLogs.sh
+++ b/scripts/checkConsoleLogs.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 EXITCODE=0
 PTRN='console\.log'


### PR DESCRIPTION
## Background
The issue #631 relate to the test failing because the tensorflow environment: custom-test-env.js couldn't be found. 

- This means that
   1.  Either the environment is located on a different directory and the README.md need to be modified
   2. Either either the test environment should be generated

## Solution
Turns out the environment does exist and the path in the README.md just need to be modified: 
Original: 
```
yarn test --env=./src/utils/common/models/utils/custom-test-env.js
```
Proposed modification: 
```
yarn test --env=./src/utils/models/tests/custom-test-env.js
````

## Test
Please run:
```
yarn test --env=./src/utils/models/tests/custom-test-env.js
```

### Other modification that can be discarded:
A nix flake had been added to include **yarn** and **husky** as those were'nt available in my local environment. 
Please discard those changes if this is not the intended behavior to work with nix. 