### PR TITLE
Iv updates

### DIFF
--- a/src/components/ui/DividerHeader/DividerHeader.tsx
+++ b/src/components/ui/DividerHeader/DividerHeader.tsx
@@ -18,7 +18,7 @@ export const DividerHeader = (props: DividerHeaderProps) => {
     <Divider sx={props.sx} textAlign={props.textAlign} variant={props.variant}>
       <Typography
         variant={props.typographyVariant}
-        sx={{ textTransform: "uppercase" }}
+        sx={{ textTransform: "capitalize" }}
       >
         {props.children}
       </Typography>

--- a/src/components/ui/DividerHeader/DividerWithLoading.tsx
+++ b/src/components/ui/DividerHeader/DividerWithLoading.tsx
@@ -32,7 +32,7 @@ export const DividerWithLoading = ({
           fontSize: "0.875rem",
           lineHeight: "1.43",
           letterSpacing: "0.01071em",
-          textTransform: "uppercase",
+          textTransform: "capitalize",
         }}
       >
         {title}

--- a/src/components/ui/DividerHeader/FunctionalDivider.tsx
+++ b/src/components/ui/DividerHeader/FunctionalDivider.tsx
@@ -1,0 +1,53 @@
+import { Box, Typography } from "@mui/material";
+import React, { ReactNode } from "react";
+
+export const FunctionalDivider = ({
+  headerText,
+  actions,
+}: {
+  headerText: string;
+  actions: ReactNode;
+}) => {
+  return (
+    <Box display="flex" alignItems="center" my={1}>
+      <Box
+        sx={(theme) => ({
+          height: 0,
+          borderBottom: `thin solid ${theme.palette.divider}`,
+          width: "7%",
+        })}
+      />
+      <Typography
+        sx={{
+          //reapply formatting of DividerHeader
+          margin: 0,
+          pl: "calc(8px* 1.2)",
+          pr: "calc(8px* 1.2)",
+          fontFamily: '"Roboto","Helvetica","Arial",sans-serif',
+          fontWeight: "400",
+          fontSize: "0.875rem",
+          lineHeight: "1.43",
+          letterSpacing: "0.01071em",
+          textTransform: "capitalize",
+        }}
+      >
+        {headerText}
+      </Typography>
+      <Box
+        sx={(theme) => ({
+          height: 0,
+          borderBottom: `thin solid ${theme.palette.divider}`,
+          flexGrow: 1,
+        })}
+      />
+      {actions}
+      <Box
+        sx={(theme) => ({
+          height: 0,
+          borderBottom: `thin solid ${theme.palette.divider}`,
+          width: "5%",
+        })}
+      />
+    </Box>
+  );
+};

--- a/src/components/ui/DividerHeader/index.ts
+++ b/src/components/ui/DividerHeader/index.ts
@@ -1,2 +1,3 @@
 export { DividerHeader } from "./DividerHeader";
 export { DividerWithLoading } from "./DividerWithLoading";
+export { FunctionalDivider } from "./FunctionalDivider";

--- a/src/store/imageViewer/imageViewerListeners.ts
+++ b/src/store/imageViewer/imageViewerListeners.ts
@@ -48,9 +48,17 @@ startAppListening({
     }
 
     listenerAPI.dispatch(imageViewerSlice.actions.setImageStack({ imageIds }));
-    // listenerAPI.dispatch(
-    //   imageViewerSlice.actions.setSelectedAnnotationIds({ annotationIds })
-    // );
+    listenerAPI.dispatch(
+      imageViewerSlice.actions.setSelectedAnnotationIds({
+        annotationIds,
+        workingAnnotationId: annotationIds[0],
+      })
+    );
+    listenerAPI.dispatch(
+      imageViewerSlice.actions.setWorkingAnnotation({
+        annotation: annotationIds[0],
+      })
+    );
     listenerAPI.dispatch(
       imageViewerSlice.actions.setActiveImageId({
         imageId: activeImageId,
@@ -125,6 +133,20 @@ startAppListening({
       })
     );
     listenerAPI.subscribe();
+  },
+});
+
+startAppListening({
+  actionCreator: imageViewerSlice.actions.setAllSelectedAnnotationIds,
+  effect: (action, listenerAPI) => {
+    const { imageViewer } = listenerAPI.getState();
+    const activeAnnotationId = imageViewer.activeAnnotationIds[0];
+
+    listenerAPI.dispatch(
+      imageViewerSlice.actions.setWorkingAnnotation({
+        annotation: activeAnnotationId,
+      })
+    );
   },
 });
 

--- a/src/store/imageViewer/imageViewerListeners.ts
+++ b/src/store/imageViewer/imageViewerListeners.ts
@@ -27,7 +27,6 @@ startAppListening({
     let imageIds: string[] = [];
     const annotationIds: string[] = [];
     let activeImageId: string | undefined = undefined;
-
     selectedThingIds.forEach((thingId) => {
       const thing = getCompleteEntity(dataState.things.entities[thingId]);
       if (thing) {

--- a/src/store/project/projectListeners.ts
+++ b/src/store/project/projectListeners.ts
@@ -103,7 +103,7 @@ startAppListening({
   effect: async (action, listenerApi) => {
     const { classifier } = listenerApi.getState();
 
-    if (action.payload.channels) {
+    if (action.payload && action.payload.channels) {
       listenerApi.dispatch(
         classifierSlice.actions.updateInputShape({
           inputShape: {

--- a/src/views/ImageViewer/sections/AnnotatorToolDrawer/ToolOptions/PointerSelectionOptions.tsx
+++ b/src/views/ImageViewer/sections/AnnotatorToolDrawer/ToolOptions/PointerSelectionOptions.tsx
@@ -36,6 +36,9 @@ export const PointerSelectionOptions = () => {
         workingAnnotationId: undefined,
       })
     );
+    dispatch(
+      imageViewerSlice.actions.setWorkingAnnotation({ annotation: undefined })
+    );
   };
 
   const handleSelectCategory = (categoryId: string) => {

--- a/src/views/ImageViewer/sections/AnnotatorToolDrawer/ToolOptions/PointerSelectionOptions.tsx
+++ b/src/views/ImageViewer/sections/AnnotatorToolDrawer/ToolOptions/PointerSelectionOptions.tsx
@@ -1,13 +1,17 @@
-import React from "react";
-import { useDispatch, useSelector } from "react-redux";
+import React, { useMemo, useState } from "react";
+import { batch, useDispatch, useSelector } from "react-redux";
 
-import { Divider, List, SvgIcon } from "@mui/material";
+import { Collapse, Divider, IconButton, List, SvgIcon } from "@mui/material";
 import { Label as LabelIcon } from "@mui/icons-material";
 
 import { useTranslation } from "hooks";
 
 import { CustomListItemButton } from "components/ui/CustomListItemButton";
-import { CollapsibleListItem } from "components/ui/CollapsibleListItem";
+
+import {
+  KeyboardArrowRight as KeyboardArrowRightIcon,
+  KeyboardArrowDown as KeyboardArrowDownIcon,
+} from "@mui/icons-material";
 
 import { imageViewerSlice } from "store/imageViewer";
 import { selectAllCategories } from "store/data/selectors";
@@ -16,6 +20,8 @@ import { selectActiveAnnotations } from "store/imageViewer/reselectors";
 import { ReactComponent as InvertSelectionIcon } from "icons/InvertAnnotation.svg";
 
 import { OldCategory } from "store/data/types";
+import { groupBy } from "lodash";
+import { DividerHeader, FunctionalDivider } from "components/ui/DividerHeader";
 
 export const PointerSelectionOptions = () => {
   const t = useTranslation();
@@ -24,6 +30,13 @@ export const PointerSelectionOptions = () => {
 
   const activeAnnotations = useSelector(selectActiveAnnotations);
   const annotationCategories = useSelector(selectAllCategories);
+  const [showCategories, setShowCategories] = useState(false);
+  const groupedCategories = useMemo(() => {
+    const objectCategories = annotationCategories.filter(
+      (cat) => cat.kind !== "Image"
+    );
+    return Object.entries(groupBy(objectCategories, "kind"));
+  }, [annotationCategories]);
 
   const handleSelectAll = () => {
     dispatch(imageViewerSlice.actions.setAllSelectedAnnotationIds({}));
@@ -42,7 +55,7 @@ export const PointerSelectionOptions = () => {
   };
 
   const handleSelectCategory = (categoryId: string) => {
-    const desiredAnnotationIds = activeAnnotations.reduce(
+    const annotationIds = activeAnnotations.reduce(
       (ids: string[], annotation) => {
         if (annotation.categoryId === categoryId) {
           ids.push(annotation.id);
@@ -51,12 +64,23 @@ export const PointerSelectionOptions = () => {
       },
       []
     );
-    dispatch(
-      imageViewerSlice.actions.setSelectedAnnotationIds({
-        annotationIds: desiredAnnotationIds,
-        workingAnnotationId: desiredAnnotationIds[0],
-      })
-    );
+    batch(() => {
+      dispatch(
+        imageViewerSlice.actions.setSelectedAnnotationIds({
+          annotationIds: annotationIds,
+          workingAnnotationId: annotationIds[0],
+        })
+      );
+      dispatch(
+        imageViewerSlice.actions.setWorkingAnnotation({
+          annotation: annotationIds[0],
+        })
+      );
+    });
+  };
+
+  const handleToggleCategories = () => {
+    setShowCategories(!showCategories);
   };
 
   return (
@@ -86,29 +110,58 @@ export const PointerSelectionOptions = () => {
           dense
         />
 
-        <Divider />
+        <FunctionalDivider
+          headerText={t("Select by Category")}
+          actions={
+            <IconButton onClick={handleToggleCategories}>
+              {showCategories ? (
+                <KeyboardArrowDownIcon fontSize="small" />
+              ) : (
+                <KeyboardArrowRightIcon fontSize="small" />
+              )}
+            </IconButton>
+          }
+        />
 
-        <CollapsibleListItem
-          beginCollapsed
-          primaryText={t("Select by Category")}
-          carotPosition="start"
-          dense
-        >
-          <List>
-            {annotationCategories.map((category: OldCategory, idx: number) => {
-              return (
-                <CustomListItemButton
-                  key={idx}
-                  primaryText={category.name}
-                  onClick={() => handleSelectCategory(category.id)}
-                  icon={<LabelIcon style={{ color: category.color }} />}
-                  dense
-                  disableGutters
-                />
-              );
-            })}
-          </List>
-        </CollapsibleListItem>
+        <Collapse in={showCategories} sx={{ px: 1 }}>
+          {groupedCategories.map(([kind, categories]) => {
+            return (
+              <React.Fragment key={kind}>
+                <DividerHeader
+                  key={kind}
+                  typographyVariant="body2"
+                  textAlign="left"
+                >
+                  {kind}
+                </DividerHeader>
+                <List sx={{ pl: 4 }}>
+                  {categories.map((category: OldCategory, idx: number) => {
+                    return (
+                      <CustomListItemButton
+                        key={`${kind}-${idx}`}
+                        primaryText={category.name}
+                        onClick={() => handleSelectCategory(category.id)}
+                        icon={
+                          <LabelIcon
+                            sx={{ color: category.color }}
+                            fontSize="small"
+                          />
+                        }
+                        sx={{
+                          "& .MuiListItemIcon-root": {
+                            minWidth: 25,
+                          },
+                        }}
+                        dense
+                        disableGutters
+                      />
+                    );
+                  })}
+                </List>
+              </React.Fragment>
+            );
+          })}
+        </Collapse>
       </List>
     </>
   );

--- a/src/views/ImageViewer/sections/ImageViewerDrawer/ImageViewerDrawer.tsx
+++ b/src/views/ImageViewer/sections/ImageViewerDrawer/ImageViewerDrawer.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { useSelector } from "react-redux";
-import { Box, Divider, IconButton, List, Typography } from "@mui/material";
+import { Divider, IconButton, List } from "@mui/material";
 import { Add } from "@mui/icons-material";
 
 import { useDialogHotkey } from "hooks";
 
 import { AppBarOffset } from "components/ui/AppBarOffset";
-import { DividerHeader } from "components/ui/DividerHeader";
+import { DividerHeader, FunctionalDivider } from "components/ui/DividerHeader";
 import { BaseAppDrawer } from "components/layout";
 import { ExportAnnotationsListItem } from "components/file-io";
 import { CreateKindDialog } from "components/dialogs";
@@ -52,57 +52,15 @@ export const ImageViewerDrawer = () => {
         </DividerHeader>
 
         <ImageList images={imageViewerImages} />
-        <Box display="flex" alignItems="center" my={1}>
-          <Box
-            sx={(theme) => ({
-              height: 0,
-              borderBottom: `thin solid ${theme.palette.divider}`,
-              width: "7%",
-            })}
-          />
-          <Typography
-            sx={{
-              //reapply formatting of DividerHeader
-              margin: 0,
-              pl: "calc(8px* 1.2)",
-              pr: "calc(8px* 1.2)",
-              fontFamily: '"Roboto","Helvetica","Arial",sans-serif',
-              fontWeight: "400",
-              fontSize: "0.875rem",
-              lineHeight: "1.43",
-              letterSpacing: "0.01071em",
-              textTransform: "uppercase",
-            }}
-          >
-            Kinds
-          </Typography>
-          <Box
-            sx={(theme) => ({
-              height: 0,
-              borderBottom: `thin solid ${theme.palette.divider}`,
-              flexGrow: 1,
-            })}
-          />
-          <IconButton
-            disableRipple
-            sx={(theme) => ({
-              p: 0,
-              pl: "calc(8px* 1.2)",
-              pr: "calc(8px* 1.2)",
-              "&:hover": { color: theme.palette.primary.main },
-            })}
-            onClick={handleOpenCreateKindDialog}
-          >
-            <Add fontSize="small" />
-          </IconButton>
-          <Box
-            sx={(theme) => ({
-              height: 0,
-              borderBottom: `thin solid ${theme.palette.divider}`,
-              width: "5%",
-            })}
-          />
-        </Box>
+
+        <FunctionalDivider
+          headerText="Kinds"
+          actions={
+            <IconButton onClick={handleOpenCreateKindDialog}>
+              <Add fontSize="small" />
+            </IconButton>
+          }
+        />
 
         <ImageViewerCategories />
 

--- a/src/views/ImageViewer/sections/Stage/Annotations/AnnotationTransformer/AnnotationTransformer.tsx
+++ b/src/views/ImageViewer/sections/Stage/Annotations/AnnotationTransformer/AnnotationTransformer.tsx
@@ -45,11 +45,13 @@ const labelPosition = {
 type AnnotationTransformerProps = {
   annotationId: string;
   annotationTool: AnnotationTool;
+  hasControl?: boolean;
 };
 
 export const AnnotationTransformer = ({
   annotationId,
   annotationTool,
+  hasControl,
 }: AnnotationTransformerProps) => {
   const stageRef = useContext(StageContext);
 
@@ -254,93 +256,89 @@ export const AnnotationTransformer = ({
   );
 
   return (
-    <>
-      <ReactKonva.Group>
-        <ReactKonva.Transformer
-          id={"tr-".concat(annotationId)}
-          ref={trRef}
-          rotateEnabled={false}
-          resizeEnabled={false}
-          borderStrokeWidth={1}
-          borderStroke="white" //TODO: It would be pretty cool if the border color could set depending on the primary color of the underlying image for contrast
-        />
-        {/* {workingAnnotation && ( */}
-        <>
-          <ReactKonva.Group
-            id={"label-group"}
-            position={{ x: xPos, y: yPos }}
-            scaleX={1 / (stageRef?.current?.scaleX() ?? 1)}
-            scaleY={1 / (stageRef?.current?.scaleX() ?? 1)}
+    <ReactKonva.Group>
+      <ReactKonva.Transformer
+        id={"tr-".concat(annotationId)}
+        ref={trRef}
+        rotateEnabled={false}
+        resizeEnabled={false}
+        borderStrokeWidth={1}
+        borderStroke="white" //TODO: It would be pretty cool if the border color could set depending on the primary color of the underlying image for contrast
+      />
+      {hasControl && (
+        <ReactKonva.Group
+          id={"label-group"}
+          position={{ x: xPos, y: yPos }}
+          scaleX={1 / (stageRef?.current?.scaleX() ?? 1)}
+          scaleY={1 / (stageRef?.current?.scaleX() ?? 1)}
+        >
+          <ReactKonva.Label
+            position={{
+              x: labelPosition.x,
+              y: labelPosition.y1,
+            }}
+            onClick={handleConfirmOrDeleteAnnotation}
+            onTap={handleConfirmOrDeleteAnnotation}
+            id={"label"}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
           >
-            <ReactKonva.Label
-              position={{
-                x: labelPosition.x,
-                y: labelPosition.y1,
-              }}
-              onClick={handleConfirmOrDeleteAnnotation}
-              onTap={handleConfirmOrDeleteAnnotation}
-              id={"label"}
-              onMouseEnter={handleMouseEnter}
-              onMouseLeave={handleMouseLeave}
-            >
-              <ReactKonva.Tag
-                cornerRadius={3}
-                fill={"darkgreen"}
-                lineJoin={"round"}
-                shadowColor={"black"}
-                shadowBlur={10}
-                shadowOffset={{ x: 5, y: 5 }}
-              />
-              <ReactKonva.Text
-                fill={"white"}
-                fontSize={14}
-                padding={6}
-                text={
-                  activeAnnotationIds.includes(annotationId) &&
-                  Object.keys(workingAnnotation.changes).length === 0
-                    ? "Delete"
-                    : "Confirm"
-                }
-                width={buttonWidth}
-                height={buttonHeight}
-                align={"center"}
-                name={"transformer-button"}
-              />
-            </ReactKonva.Label>
-            <ReactKonva.Label
-              position={{
-                x: labelPosition.x,
-                y: labelPosition.y2,
-              }}
-              onClick={cancelAnnotationHandler}
-              onTap={cancelAnnotationHandler}
-              id={"label"}
-              onMouseEnter={handleMouseEnter}
-              onMouseLeave={handleMouseLeave}
-            >
-              <ReactKonva.Tag
-                cornerRadius={3}
-                fill={"darkred"}
-                lineJoin={"round"}
-                shadowColor={"black"}
-                shadowBlur={10}
-                shadowOffset={{ x: 5, y: 5 }}
-              />
-              <ReactKonva.Text
-                fill={"white"}
-                fontSize={14}
-                padding={6}
-                text={"Cancel"}
-                width={buttonWidth}
-                height={buttonHeight}
-                align={"center"}
-                name={"transformer-button"}
-              />
-            </ReactKonva.Label>
-          </ReactKonva.Group>
-        </>
-        {/* )} */}
-      </ReactKonva.Group>
-    </>
+            <ReactKonva.Tag
+              cornerRadius={3}
+              fill={"darkgreen"}
+              lineJoin={"round"}
+              shadowColor={"black"}
+              shadowBlur={10}
+              shadowOffset={{ x: 5, y: 5 }}
+            />
+            <ReactKonva.Text
+              fill={"white"}
+              fontSize={14}
+              padding={6}
+              text={
+                activeAnnotationIds.includes(annotationId) &&
+                Object.keys(workingAnnotation.changes).length === 0
+                  ? "Delete"
+                  : "Confirm"
+              }
+              width={buttonWidth}
+              height={buttonHeight}
+              align={"center"}
+              name={"transformer-button"}
+            />
+          </ReactKonva.Label>
+          <ReactKonva.Label
+            position={{
+              x: labelPosition.x,
+              y: labelPosition.y2,
+            }}
+            onClick={cancelAnnotationHandler}
+            onTap={cancelAnnotationHandler}
+            id={"label"}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+          >
+            <ReactKonva.Tag
+              cornerRadius={3}
+              fill={"darkred"}
+              lineJoin={"round"}
+              shadowColor={"black"}
+              shadowBlur={10}
+              shadowOffset={{ x: 5, y: 5 }}
+            />
+            <ReactKonva.Text
+              fill={"white"}
+              fontSize={14}
+              padding={6}
+              text={"Cancel"}
+              width={buttonWidth}
+              height={buttonHeight}
+              align={"center"}
+              name={"transformer-button"}
+            />
+          </ReactKonva.Label>
+        </ReactKonva.Group>
+      )}
+    </ReactKonva.Group>
   );
 };

--- a/src/views/ImageViewer/sections/Stage/Annotations/Annotations.tsx
+++ b/src/views/ImageViewer/sections/Stage/Annotations/Annotations.tsx
@@ -76,6 +76,7 @@ export const Annotations = ({ annotationTool }: AnnotationsProps) => {
             key={`tr-${workingAnnotationObject.annotation.id}`}
             annotationId={workingAnnotationObject.annotation.id}
             annotationTool={annotationTool}
+            hasControl={true}
           />
         </>
       )}

--- a/src/views/ImageViewer/sections/Stage/Stage.tsx
+++ b/src/views/ImageViewer/sections/Stage/Stage.tsx
@@ -62,8 +62,6 @@ import { HotkeyContext } from "utils/common/enums";
 
 import { Category, Kind } from "store/data/types";
 
-const normalizeFont = 1300;
-
 export const Stage = ({
   stageWidth,
   stageHeight,
@@ -277,17 +275,7 @@ export const Stage = ({
             <DndProvider backend={HTML5Backend}>
               <Layer>
                 {!(htmlImages && htmlImages.length) ? (
-                  <ReactKonva.Text
-                    x={stageWidth / 6} //center depending on window width
-                    y={0.4 * stageHeight}
-                    width={(2 * stageWidth) / 3}
-                    align="center"
-                    text={
-                      'To start annotating, drag and drop an image onto the canvas or click on "Open Image".'
-                    }
-                    fill={"black"}
-                    fontSize={(30 * stageWidth) / normalizeFont} //scale font depending on window width
-                  />
+                  <></>
                 ) : !imageIsLoading ? (
                   <Image
                     ref={imageRef}

--- a/src/views/ProjectViewer/components/dialogs/OpenExampleDialog/ExampleImageCard/ExampleImageCard.tsx
+++ b/src/views/ProjectViewer/components/dialogs/OpenExampleDialog/ExampleImageCard/ExampleImageCard.tsx
@@ -54,6 +54,7 @@ export const ExampleImageCard = ({
     });
 
     batch(() => {
+      dispatch(projectSlice.actions.resetProject());
       dispatch(projectSlice.actions.setProjectImageChannels({ channels: 3 }));
       dispatch(
         dataSlice.actions.initializeState({


### PR DESCRIPTION
Contains a handful of ImageViewer updates:
- UI
 - removes drag and drop text, since we no longer support that
 - select-by-category grouped by kind
- Bug Fixes
 - resets project when loading example image, otherwise previously selected images persist in store, throwing error when moving to ImageViewer
 - sets correct position of control labels by correctly setting "workingAnnotation" when using group selection buttons (all, by-category), and when moving to ImageViewer (prepareImageViewer action listener)