### PR TITLE
ui-update/displays full measurement name

### DIFF
--- a/src/views/MeasurementView/sections/MeasurementsTableContainer/MeasurementTable.tsx
+++ b/src/views/MeasurementView/sections/MeasurementsTableContainer/MeasurementTable.tsx
@@ -76,7 +76,6 @@ export const MeasurementTable = ({
     return Object.entries(tableMeasurements).reduce(
       (measurementRows: ExtendedDisplayTableRow[], measurementType, idx) => {
         const type = measurementType[0].split(" ");
-        type.splice(1, 1);
         const typeSplitString = type.join(" ");
         const idx1 = idx;
         measurementType[1].splits.forEach((row, idx) => {


### PR DESCRIPTION
Measurement names were excluding second word, which made object measurement name more concise but intensity names incorrect.

Object Geometry Area -> Object Area
Intensity Mean Channel 0 -> Intensity Channel 0

The fix makes it so the whole name is displayed.