### PR TITLE
Fix build error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /coverage
 /node_modules
 build
+dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -2,11 +2,30 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import viteTsconfigPaths from "vite-tsconfig-paths";
+import path from "path";
 
 export default defineConfig({
   // depending on your application, base can also be "/"
   base: "",
   plugins: [react(), viteTsconfigPaths()],
+  // vite in dev mode works without this
+  // but on build rollup fails to resolve these
+  // would be nice to figure out a more robust config that both understand
+  resolve: {
+    alias: {
+      utils: path.resolve("src/utils/"),
+      views: path.resolve("src/views/"),
+      components: path.resolve("src/components"),
+      contexts: path.resolve("src/contexts"),
+      data: path.resolve("src/data"),
+      hooks: path.resolve("src/hooks"),
+      icons: path.resolve("src/icons"),
+      images: path.resolve("src/images"),
+      store: path.resolve("src/store"),
+      themes: path.resolve("src/themes"),
+      translations: path.resolve("src/translations"),
+    },
+  },
 
   server: {
     // this ensures that the browser opens upon server start


### PR DESCRIPTION
- vite is configured to resolve absolute pathnames from src
- this works for dev mode (pnpm start, etc)
- this breaks for build (pnpm build) because rollup is more strict
- add aliases for all top level src/ directories for rollup resolution